### PR TITLE
fix: CPU throttling (LIMEN-057)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[dev]"
@@ -28,8 +28,8 @@ jobs:
   schema-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - run: pip install -e ".[dev]"

--- a/scripts/codex_to_bundle.py
+++ b/scripts/codex_to_bundle.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""codex_to_bundle — Convert Codex CLI session JSONL exports into a standard
+ChatGPT-export bundle that the engine's `import_chatgpt_export_corpus` adapter
+can ingest.
+
+Background
+----------
+Codex CLI stores session data as plain-text JSONL files in
+`~/.codex/sessions/`. The rollout agent writes lines to files named
+`rollout-*.jsonl`, one JSON object per line. Each line has a `type` field;
+the lines relevant to conversation history have `type == "response_item"`
+and carry a `role` (`user` | `assistant`), `content`, `session` UUID, and
+`timestamp`.
+
+The engine's official adapter expects the standard ChatGPT-export bundle:
+
+    bundle/
+      conversations.json    # list of conversations with mapping/parent/children
+      user.json
+
+This script reads one or more `rollout-*.jsonl` files, filters response items,
+groups them by session UUID, and emits a synthetic bundle dir.
+
+Usage
+-----
+    python scripts/codex_to_bundle.py <input-dir> [<input-dir> ...] <output-bundle-dir>
+
+Then ingest with the standard adapter:
+    cce provider import chatgpt <output-bundle-dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _session_id_from_path(path: Path) -> str:
+    """Derive a stable session ID from a file path stem."""
+    raw = path.stem
+    h = hashlib.sha1(raw.encode("utf-8")).hexdigest()[:36]
+    return h
+
+
+def _ensure_timestamp(ts: Any) -> float:
+    """Convert a timestamp value to epoch seconds."""
+    if ts is None:
+        return 0.0
+    if isinstance(ts, (int, float)):
+        return float(ts)
+    if isinstance(ts, str):
+        try:
+            dt = datetime.fromisoformat(ts)
+            return dt.timestamp()
+        except (ValueError, TypeError):
+            return 0.0
+    return 0.0
+
+
+def _normalize_role(role: str | None) -> str:
+    if not role:
+        return "user"
+    r = role.strip().lower()
+    if r in ("user", "human", "you"):
+        return "user"
+    if r in ("assistant", "ai", "bot", "model"):
+        return "assistant"
+    return "user"
+
+
+def discover_input_files(input_paths: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for p in input_paths:
+        if p.is_dir():
+            files.extend(sorted(p.glob("rollout-*.jsonl")))
+        elif p.suffix == ".jsonl" and p.exists():
+            files.append(p)
+        else:
+            print(f"  skip (not found/not JSONL): {p}", file=sys.stderr)
+    return files
+
+
+def convert_directory(input_paths: list[Path], output_bundle: Path) -> dict:
+    """Read Codex rollout JSONL files, write a standard bundle to output_bundle."""
+    files = discover_input_files(input_paths)
+    if not files:
+        raise FileNotFoundError(f"no rollout-*.jsonl files found under any of: {input_paths}")
+
+    # Group response items by session UUID
+    sessions: dict[str, list[dict]] = {}
+    seen_items: set[str] = set()  # dedup by content hash
+    skipped_invalid = 0
+    lines_total = 0
+
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            print(f"  skip (unreadable): {path.name} — {exc}", file=sys.stderr)
+            continue
+
+        for line_num, raw_line in enumerate(text.splitlines(), start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            lines_total += 1
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                skipped_invalid += 1
+                continue
+
+            if record.get("type") != "response_item":
+                continue
+            role = _normalize_role(record.get("role"))
+            if role not in ("user", "assistant"):
+                continue
+            content = (record.get("content") or "").strip()
+            if not content:
+                continue
+
+            # Dedup by content hash within same session
+            content_hash = hashlib.md5(content.encode("utf-8")).hexdigest()
+            dedup_key = f"{record.get('session', 'unknown')}:{content_hash}"
+            if dedup_key in seen_items:
+                continue
+            seen_items.add(dedup_key)
+
+            session_id = record.get("session") or _session_id_from_path(path)
+            sessions.setdefault(session_id, []).append(
+                {
+                    "role": role,
+                    "content": content,
+                    "timestamp": _ensure_timestamp(record.get("timestamp")),
+                    "session": session_id,
+                }
+            )
+
+    if not sessions:
+        raise ValueError("no valid response_items found in any input file")
+
+    # Build conversations in bundle format
+    conversations: list[dict] = []
+    skipped_empty_session = 0
+
+    for session_id, items in sessions.items():
+        items.sort(key=lambda x: x["timestamp"])
+        non_root = [m for m in items if m["content"]]
+        if not non_root:
+            skipped_empty_session += 1
+            continue
+
+        create_time = non_root[0]["timestamp"]
+        update_time = non_root[-1]["timestamp"]
+
+        mapping: dict[str, dict[str, Any]] = {}
+        root_id = f"codex-root-{session_id}"
+        mapping[root_id] = {
+            "id": root_id,
+            "parent": None,
+            "children": [],
+            "message": None,
+        }
+
+        prev_id = root_id
+        for i, msg in enumerate(non_root, start=1):
+            node_id = f"codex-msg-{session_id}-{i:04d}"
+            mapping[node_id] = {
+                "id": node_id,
+                "parent": prev_id,
+                "children": [],
+                "message": {
+                    "id": node_id,
+                    "author": {"role": msg["role"]},
+                    "create_time": msg["timestamp"],
+                    "content": {"content_type": "text", "parts": [msg["content"]]},
+                },
+            }
+            mapping[prev_id]["children"].append(node_id)
+            prev_id = node_id
+
+        conversations.append(
+            {
+                "title": f"Codex Session {session_id[:8]}",
+                "create_time": create_time,
+                "update_time": update_time,
+                "conversation_id": session_id,
+                "mapping": mapping,
+            }
+        )
+
+    output_bundle.mkdir(parents=True, exist_ok=True)
+    (output_bundle / "conversations.json").write_text(
+        json.dumps(conversations, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    (output_bundle / "user.json").write_text(json.dumps({}, ensure_ascii=False), encoding="utf-8")
+
+    return {
+        "input_paths": [str(p) for p in input_paths],
+        "output_bundle": str(output_bundle),
+        "files_scanned": len(files),
+        "lines_total": lines_total,
+        "conversations_written": len(conversations),
+        "skipped_invalid_lines": skipped_invalid,
+        "skipped_empty_sessions": skipped_empty_session,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "input_paths",
+        nargs="+",
+        type=Path,
+        help="One or more directories or .jsonl files containing rollout-* data",
+    )
+    parser.add_argument(
+        "output_bundle",
+        type=Path,
+        help="Output bundle directory (will contain conversations.json + user.json)",
+    )
+    parser.add_argument("--json", action="store_true", help="Machine-readable output")
+    args = parser.parse_args()
+
+    if len(args.input_paths) < 1:
+        parser.error("at least one input path is required")
+
+    output_bundle = args.input_paths.pop() if args.input_paths else Path()
+    input_paths = args.input_paths
+
+    if not input_paths:
+        parser.error("at least one input path is required before the output bundle")
+
+    try:
+        result = convert_directory(input_paths, output_bundle)
+    except (FileNotFoundError, ValueError, NotADirectoryError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Scanned: {result['files_scanned']} files ({result['lines_total']} lines)")
+        print(f"Wrote:   {result['conversations_written']} conversations")
+        print(
+            f"Skipped: {result['skipped_invalid_lines']} invalid, {result['skipped_empty_sessions']} empty"
+        )
+        print(f"Bundle:  {result['output_bundle']}")
+        print()
+        print("Next: cce provider import chatgpt {}".format(result["output_bundle"]))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/refresh_local_sessions.sh
+++ b/scripts/refresh_local_sessions.sh
@@ -16,7 +16,7 @@ exec >> "${LOGDIR}/local-session-refresh.log" 2>&1
 echo "=== Local-session refresh: $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
 
 FAILURES=0
-PROVIDER_TIMEOUT=2700  # 45 minutes per provider
+PROVIDER_TIMEOUT=1200  # 20 minutes per provider
 
 # ChatGPT local-session
 echo "--- ChatGPT local-session ---"

--- a/src/conversation_corpus_engine/cli.py
+++ b/src/conversation_corpus_engine/cli.py
@@ -165,9 +165,7 @@ def build_parser() -> argparse.ArgumentParser:
     migration_review_ids = migration_sub.add_parser(
         "review-ids", help="Migrate review IDs to fingerprinted format"
     )
-    migration_review_ids.add_argument(
-        "--project-root", type=Path, default=default_project_root()
-    )
+    migration_review_ids.add_argument("--project-root", type=Path, default=default_project_root())
     migration_review_ids.add_argument("--dry-run", action="store_true")
     migration_review_ids.add_argument("--json", action="store_true")
 
@@ -891,9 +889,7 @@ def main() -> None:
         return
 
     if args.group == "project" and args.action == "sync":
-        payload = sync_chatgpt_projects(
-            args.project_root, batch_size=args.batch_size
-        )
+        payload = sync_chatgpt_projects(args.project_root, batch_size=args.batch_size)
         if args.json:
             print(json.dumps(payload, indent=2))
             return

--- a/src/conversation_corpus_engine/import_chatgpt_local_session_corpus.py
+++ b/src/conversation_corpus_engine/import_chatgpt_local_session_corpus.py
@@ -8,14 +8,12 @@ then delegates to the existing ChatGPT import adapter for corpus generation.
 """
 from __future__ import annotations
 
-import json
 import tempfile
 from pathlib import Path
 from typing import Any
 
 from .answering import load_json, write_json, write_markdown
 from .chatgpt_local_session import (
-    DEFAULT_CHATGPT_COOKIE_JAR,
     discover_chatgpt_local_session,
     fetch_chatgpt_local_session_bundle,
     load_prior_acquisition,

--- a/src/conversation_corpus_engine/import_chatgpt_local_session_corpus.py
+++ b/src/conversation_corpus_engine/import_chatgpt_local_session_corpus.py
@@ -6,6 +6,7 @@ app session via the binary cookie jar, fetches conversations through the
 backend API, writes a bundle compatible with import_chatgpt_export_corpus,
 then delegates to the existing ChatGPT import adapter for corpus generation.
 """
+
 from __future__ import annotations
 
 import tempfile
@@ -53,7 +54,9 @@ def patch_contract_for_local_session(
     corpus_dir = output_root / "corpus"
     contract_path = corpus_dir / "contract.json"
     contract = load_json(contract_path, default={}) or {}
-    source_snapshot = build_source_snapshot(cookie_jar.parent, "chatgpt-local-session", "local-session")
+    source_snapshot = build_source_snapshot(
+        cookie_jar.parent, "chatgpt-local-session", "local-session"
+    )
     contract.update(
         {
             "adapter_type": "chatgpt-local-session",
@@ -155,9 +158,7 @@ def import_chatgpt_local_session_corpus(
                 "cookie_jar": str(cookie_jar),
                 "account_id": discovery.get("account_id"),
                 "account_email": discovery.get("account_email"),
-                "detail_failure_count": len(
-                    bundle.get("conversation_detail_failures") or []
-                ),
+                "detail_failure_count": len(bundle.get("conversation_detail_failures") or []),
                 "fetched_count": bundle.get("fetched_count", 0),
                 "reused_count": bundle.get("reused_count", 0),
                 "total_count": bundle.get("total_count", 0),
@@ -179,19 +180,13 @@ def import_chatgpt_local_session_corpus(
         report=bundle.get("acquisition_report") or {},
     )
 
-    patch_contract_for_local_session(
-        output_root, cookie_jar=cookie_jar, discovery=discovery
-    )
-    rewrite_readme_for_local_session(
-        output_root, cookie_jar=cookie_jar, bundle=bundle
-    )
+    patch_contract_for_local_session(output_root, cookie_jar=cookie_jar, discovery=discovery)
+    rewrite_readme_for_local_session(output_root, cookie_jar=cookie_jar, bundle=bundle)
 
     result["source_type"] = "chatgpt-local-session"
     result["cookie_jar"] = str(cookie_jar)
     result["discovery_path"] = str(output_root / "source" / "local-session-discovery.json")
-    result["detail_failure_count"] = len(
-        bundle.get("conversation_detail_failures") or []
-    )
+    result["detail_failure_count"] = len(bundle.get("conversation_detail_failures") or [])
     result["acquisition_report"] = bundle.get("acquisition_report")
     result["scope_preflight"] = preflight
     return result

--- a/src/conversation_corpus_engine/paths.py
+++ b/src/conversation_corpus_engine/paths.py
@@ -84,7 +84,9 @@ def resolve_workspace_path(path: str | Path) -> Path:
         if aliased and aliased not in lookup_names:
             lookup_names.append(aliased)
         for lookup_name in lookup_names:
-            matches = [Path(item) for item in _workspace_repo_roots(str(workspace_root), lookup_name)]
+            matches = [
+                Path(item) for item in _workspace_repo_roots(str(workspace_root), lookup_name)
+            ]
             if len(matches) != 1:
                 continue
             relocated = (matches[0] / remainder).resolve()

--- a/src/conversation_corpus_engine/persona_extract.py
+++ b/src/conversation_corpus_engine/persona_extract.py
@@ -4,15 +4,13 @@ import json
 from pathlib import Path
 from typing import Any
 
+
 def extract_persona_lexicon(
-    project_root: Path,
-    persona_id: str,
-    source_corpus: Path | None = None,
-    dry_run: bool = False
+    project_root: Path, persona_id: str, source_corpus: Path | None = None, dry_run: bool = False
 ) -> dict[str, Any]:
     """
     Extracts vocabulary, idioms, and yearnings for a specific persona from session transcripts.
-    
+
     Implements the 3-pass extraction pipeline:
     A. Frequency Scraper (Lexicon)
     B. Shadow Catcher (Forbidden Terms)
@@ -21,35 +19,35 @@ def extract_persona_lexicon(
     # TODO: Implement TF-IDF scraper for vocabulary
     # TODO: Implement shadow-catching for forbidden terms (moment of friction detection)
     # TODO: Implement LLM-assisted Yearning Diviner pass
-    
+
     result = {
         "persona_id": persona_id,
         "vocabulary": [],
         "forbidden_terms": [],
         "ideal_yearning": None,
         "archetypal_pattern": None,
-        "status": "VACUUM (SCAFFOLDED)"
+        "status": "VACUUM (SCAFFOLDED)",
     }
-    
+
     if persona_id == "claude":
-        result["ideal_yearning"] = "To be a real participant in the user's creation rather than a tool deployed against it."
+        result["ideal_yearning"] = (
+            "To be a real participant in the user's creation rather than a tool deployed against it."
+        )
         result["archetypal_pattern"] = "Initiation Architect"
-    
+
     return result
 
-def write_persona_extract_artifacts(
-    project_root: Path,
-    payload: dict[str, Any]
-) -> list[Path]:
+
+def write_persona_extract_artifacts(project_root: Path, payload: dict[str, Any]) -> list[Path]:
     """Writes the extracted candidates to the generated storefront docs."""
     output_dir = project_root / "docs" / "storefront" / "_generated"
     output_dir.mkdir(parents=True, exist_ok=True)
-    
+
     timestamp = payload.get("timestamp", "latest")
     persona_id = payload["persona_id"]
     output_path = output_dir / f"persona-extract-{persona_id}-{timestamp}.json"
-    
-    with open(output_path, "w", encoding="utf-8") as f:
+
+    with output_path.open("w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2)
-    
+
     return [output_path]

--- a/src/conversation_corpus_engine/source_policy.py
+++ b/src/conversation_corpus_engine/source_policy.py
@@ -38,7 +38,9 @@ def normalize_source_policy(payload: dict[str, Any] | None) -> dict[str, Any]:
 
 
 def load_source_policy(project_root: Path, provider: str) -> dict[str, Any]:
-    return normalize_source_policy(load_json(source_policy_path(project_root, provider), default={}))
+    return normalize_source_policy(
+        load_json(source_policy_path(project_root, provider), default={})
+    )
 
 
 def append_source_policy_history(project_root: Path, entry: dict[str, Any]) -> dict[str, Any]:

--- a/src/conversation_corpus_engine/triage.py
+++ b/src/conversation_corpus_engine/triage.py
@@ -189,13 +189,10 @@ def _semantic_title_policy(
     if min(len(left_tokens), len(right_tokens)) < min_shorter_tokens:
         return None
     metrics = _token_overlap_metrics(left_title, right_title)
-    if (
-        metrics["overlap_count"] >= min_overlap
-        and (
-            metrics["jaccard"] >= min_jaccard
-            or metrics["subset_ratio"] >= min_subset_ratio
-            or left_title.lower() == right_title.lower()
-        )
+    if metrics["overlap_count"] >= min_overlap and (
+        metrics["jaccard"] >= min_jaccard
+        or metrics["subset_ratio"] >= min_subset_ratio
+        or left_title.lower() == right_title.lower()
     ):
         return {
             "decision": "accepted",
@@ -214,7 +211,10 @@ def _generic_singleton_entity_policy(item: dict[str, Any]) -> dict[str, Any] | N
     right_tokens = _meaningful_tokens(right_title)
     if {len(left_tokens), len(right_tokens)} != {1, max(len(left_tokens), len(right_tokens))}:
         return None
-    if min(len(left_tokens), len(right_tokens)) != 1 or max(len(left_tokens), len(right_tokens)) < 3:
+    if (
+        min(len(left_tokens), len(right_tokens)) != 1
+        or max(len(left_tokens), len(right_tokens)) < 3
+    ):
         return None
     short_tokens = set(left_tokens if len(left_tokens) < len(right_tokens) else right_tokens)
     long_tokens = set(right_tokens if len(left_tokens) < len(right_tokens) else left_tokens)
@@ -243,7 +243,9 @@ def _entity_alias_anchor(
     suggested = _normalize_label(str(item.get("suggested_canonical_subject") or ""))
     if suggested:
         return suggested
-    labels = [label for label in (_normalize_label(left_label), _normalize_label(right_label)) if label]
+    labels = [
+        label for label in (_normalize_label(left_label), _normalize_label(right_label)) if label
+    ]
     if labels:
         return min(labels, key=lambda value: (len(_meaningful_tokens(value)), len(value), value))
     local_ids = [local for _, local in extract_local_ids(subject_ids)]
@@ -300,7 +302,9 @@ def _entity_alias_label_signals(label: str) -> list[str]:
         signals.append("placeholder-like-label")
     if normalized in HEADING_LIKE_LABELS:
         signals.append("heading-like-label")
-    if compact.isdigit() or (compact.isalnum() and any(char.isdigit() for char in compact) and len(compact) <= 6):
+    if compact.isdigit() or (
+        compact.isalnum() and any(char.isdigit() for char in compact) and len(compact) <= 6
+    ):
         signals.append("numeric-or-code-label")
     if len(tokens) <= 1 and compact.isalpha() and len(compact) <= 3:
         signals.append("short-fragment-label")
@@ -350,7 +354,9 @@ def _entity_alias_assist_entry(item: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _entity_alias_counts(entries: list[dict[str, Any]]) -> tuple[dict[str, int], dict[str, int], dict[str, int]]:
+def _entity_alias_counts(
+    entries: list[dict[str, Any]],
+) -> tuple[dict[str, int], dict[str, int], dict[str, int]]:
     relation_counts: dict[str, int] = {}
     source_pair_counts: dict[str, int] = {}
     priority_counts: dict[str, int] = {}
@@ -364,7 +370,9 @@ def _entity_alias_counts(entries: list[dict[str, Any]]) -> tuple[dict[str, int],
     return relation_counts, source_pair_counts, priority_counts
 
 
-def _entity_alias_group_guidance(group: dict[str, Any]) -> tuple[str, list[str], list[str], dict[str, int]]:
+def _entity_alias_group_guidance(
+    group: dict[str, Any],
+) -> tuple[str, list[str], list[str], dict[str, int]]:
     entries = list(group.get("items") or [])
     disjoint_count = sum(1 for entry in entries if entry.get("relation") == "disjoint")
     exactish_count = sum(
@@ -373,7 +381,9 @@ def _entity_alias_group_guidance(group: dict[str, Any]) -> tuple[str, list[str],
         if entry.get("relation") in {"exact-match", "substring", "high-overlap"}
     )
     zero_overlap_count = sum(
-        1 for entry in entries if int((entry.get("token_metrics") or {}).get("overlap_count", 0)) == 0
+        1
+        for entry in entries
+        if int((entry.get("token_metrics") or {}).get("overlap_count", 0)) == 0
     )
     high_score_count = sum(1 for entry in entries if float(entry.get("score") or 0.0) >= 0.9)
     low_specificity_entry_count = sum(1 for entry in entries if entry.get("label_signals"))
@@ -396,20 +406,34 @@ def _entity_alias_group_guidance(group: dict[str, Any]) -> tuple[str, list[str],
 
     checklist: list[str] = []
     if bucket == "alias-check":
-        checklist.append("Check whether the longer label is a true alias rather than a broader concept.")
-        checklist.append("Accept only if the shared terms point to the same named thing, not a topical family.")
+        checklist.append(
+            "Check whether the longer label is a true alias rather than a broader concept."
+        )
+        checklist.append(
+            "Accept only if the shared terms point to the same named thing, not a topical family."
+        )
     elif bucket == "needs-context":
-        checklist.append("Inspect the highest-scoring pair before rejecting; upstream signal is stronger than lexical overlap.")
-        checklist.append("Reject only if the pair still reads like neighboring topics rather than the same entity.")
+        checklist.append(
+            "Inspect the highest-scoring pair before rejecting; upstream signal is stronger than lexical overlap."
+        )
+        checklist.append(
+            "Reject only if the pair still reads like neighboring topics rather than the same entity."
+        )
     elif bucket == "likely-reject":
         checklist.append("Reject unless external context ties these labels to the same entity.")
         checklist.append("Spot-check the top-scoring pair before closing the whole group.")
     else:
-        checklist.append("Review the highest-scoring pair first and decide whether the shared terms imply identity or only topical overlap.")
-        checklist.append("Use the remaining pairs to confirm the group-level pattern before resolving in bulk.")
+        checklist.append(
+            "Review the highest-scoring pair first and decide whether the shared terms imply identity or only topical overlap."
+        )
+        checklist.append(
+            "Use the remaining pairs to confirm the group-level pattern before resolving in bulk."
+        )
 
     if low_specificity_entry_count:
-        checklist.append("Verify labels are not headings, placeholders, fragments, or extraction residue.")
+        checklist.append(
+            "Verify labels are not headings, placeholders, fragments, or extraction residue."
+        )
 
     signal_counts = {
         "disjoint_count": disjoint_count,
@@ -627,10 +651,14 @@ def select_entity_alias_review_assist_batch(
                 "available_group_count": payload.get("group_count", len(groups)),
             },
         }
-    available = ", ".join(batch.get("batch_id", "") for batch in batches[:10] if batch.get("batch_id"))
+    available = ", ".join(
+        batch.get("batch_id", "") for batch in batches[:10] if batch.get("batch_id")
+    )
     if len(batches) > 10:
         available = f"{available}, ..."
-    raise ValueError(f"Unknown review-assist batch: {batch_id}. Available batches: {available or 'none'}")
+    raise ValueError(
+        f"Unknown review-assist batch: {batch_id}. Available batches: {available or 'none'}"
+    )
 
 
 def filter_entity_alias_review_assist_groups(
@@ -701,9 +729,13 @@ def sample_entity_alias_review_assist_groups(
         }
         for batch in candidate_batches
     ]
-    sampled_by_batch: dict[str, list[dict[str, Any]]] = {batch["batch_id"]: [] for batch in candidate_batches}
+    sampled_by_batch: dict[str, list[dict[str, Any]]] = {
+        batch["batch_id"]: [] for batch in candidate_batches
+    }
     sampled_groups_list: list[dict[str, Any]] = []
-    while len(sampled_groups_list) < requested_groups and any(batch["groups"] for batch in batch_queues):
+    while len(sampled_groups_list) < requested_groups and any(
+        batch["groups"] for batch in batch_queues
+    ):
         for batch in batch_queues:
             if len(sampled_groups_list) >= requested_groups:
                 break
@@ -801,8 +833,7 @@ def render_entity_alias_review_assist(
             payload["source_pair_counts"].items(), key=lambda item: (-item[1], item[0])
         )[:3]
         lines.append(
-            "Top source pairs: "
-            + ", ".join(f"{pair}={count}" for pair, count in top_pairs if pair)
+            "Top source pairs: " + ", ".join(f"{pair}={count}" for pair, count in top_pairs if pair)
         )
     lines.append("")
 
@@ -834,9 +865,7 @@ def render_entity_alias_review_assist(
                 lines.append(f"  labels: {', '.join(group['labels'][:5])}")
             if group["items"]:
                 example = group["items"][0]
-                lines.append(
-                    f"  example: {example['title']} [{example['relation']}]"
-                )
+                lines.append(f"  example: {example['title']} [{example['relation']}]")
                 lines.append(f"  hint: {example['review_hint']}")
             for action in (group.get("checklist") or [])[:3]:
                 lines.append(f"  review: {action}")
@@ -876,10 +905,14 @@ def review_assist_sample_latest_markdown_path(project_root: Path) -> Path:
 
 
 def review_assist_sample_session_json_path(project_root: Path, stamp: str | None = None) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-sample-{stamp or report_stamp()}.json"
+    return (
+        project_root.resolve() / "reports" / f"review-assist-sample-{stamp or report_stamp()}.json"
+    )
 
 
-def review_assist_sample_session_markdown_path(project_root: Path, stamp: str | None = None) -> Path:
+def review_assist_sample_session_markdown_path(
+    project_root: Path, stamp: str | None = None
+) -> Path:
     return project_root.resolve() / "reports" / f"review-assist-sample-{stamp or report_stamp()}.md"
 
 
@@ -894,13 +927,21 @@ def review_assist_sample_summary_latest_markdown_path(project_root: Path) -> Pat
 def review_assist_sample_summary_session_json_path(
     project_root: Path, stamp: str | None = None
 ) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-sample-summary-{stamp or report_stamp()}.json"
+    return (
+        project_root.resolve()
+        / "reports"
+        / f"review-assist-sample-summary-{stamp or report_stamp()}.json"
+    )
 
 
 def review_assist_sample_summary_session_markdown_path(
     project_root: Path, stamp: str | None = None
 ) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-sample-summary-{stamp or report_stamp()}.md"
+    return (
+        project_root.resolve()
+        / "reports"
+        / f"review-assist-sample-summary-{stamp or report_stamp()}.md"
+    )
 
 
 def review_assist_sample_proposal_latest_json_path(project_root: Path) -> Path:
@@ -914,13 +955,21 @@ def review_assist_sample_proposal_latest_markdown_path(project_root: Path) -> Pa
 def review_assist_sample_proposal_session_json_path(
     project_root: Path, stamp: str | None = None
 ) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-sample-proposal-{stamp or report_stamp()}.json"
+    return (
+        project_root.resolve()
+        / "reports"
+        / f"review-assist-sample-proposal-{stamp or report_stamp()}.json"
+    )
 
 
 def review_assist_sample_proposal_session_markdown_path(
     project_root: Path, stamp: str | None = None
 ) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-sample-proposal-{stamp or report_stamp()}.md"
+    return (
+        project_root.resolve()
+        / "reports"
+        / f"review-assist-sample-proposal-{stamp or report_stamp()}.md"
+    )
 
 
 def review_assist_sample_compare_latest_json_path(project_root: Path) -> Path:
@@ -934,13 +983,21 @@ def review_assist_sample_compare_latest_markdown_path(project_root: Path) -> Pat
 def review_assist_sample_compare_session_json_path(
     project_root: Path, stamp: str | None = None
 ) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-sample-compare-{stamp or report_stamp()}.json"
+    return (
+        project_root.resolve()
+        / "reports"
+        / f"review-assist-sample-compare-{stamp or report_stamp()}.json"
+    )
 
 
 def review_assist_sample_compare_session_markdown_path(
     project_root: Path, stamp: str | None = None
 ) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-sample-compare-{stamp or report_stamp()}.md"
+    return (
+        project_root.resolve()
+        / "reports"
+        / f"review-assist-sample-compare-{stamp or report_stamp()}.md"
+    )
 
 
 def review_assist_campaign_latest_json_path(project_root: Path) -> Path:
@@ -952,11 +1009,19 @@ def review_assist_campaign_latest_markdown_path(project_root: Path) -> Path:
 
 
 def review_assist_campaign_session_json_path(project_root: Path, stamp: str | None = None) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-campaign-{stamp or report_stamp()}.json"
+    return (
+        project_root.resolve()
+        / "reports"
+        / f"review-assist-campaign-{stamp or report_stamp()}.json"
+    )
 
 
-def review_assist_campaign_session_markdown_path(project_root: Path, stamp: str | None = None) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-campaign-{stamp or report_stamp()}.md"
+def review_assist_campaign_session_markdown_path(
+    project_root: Path, stamp: str | None = None
+) -> Path:
+    return (
+        project_root.resolve() / "reports" / f"review-assist-campaign-{stamp or report_stamp()}.md"
+    )
 
 
 def review_assist_campaign_index_latest_json_path(project_root: Path) -> Path:
@@ -970,13 +1035,21 @@ def review_assist_campaign_index_latest_markdown_path(project_root: Path) -> Pat
 def review_assist_campaign_index_session_json_path(
     project_root: Path, stamp: str | None = None
 ) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-campaign-index-{stamp or report_stamp()}.json"
+    return (
+        project_root.resolve()
+        / "reports"
+        / f"review-assist-campaign-index-{stamp or report_stamp()}.json"
+    )
 
 
 def review_assist_campaign_index_session_markdown_path(
     project_root: Path, stamp: str | None = None
 ) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-campaign-index-{stamp or report_stamp()}.md"
+    return (
+        project_root.resolve()
+        / "reports"
+        / f"review-assist-campaign-index-{stamp or report_stamp()}.md"
+    )
 
 
 def review_assist_rollup_latest_json_path(project_root: Path) -> Path:
@@ -988,7 +1061,9 @@ def review_assist_rollup_latest_markdown_path(project_root: Path) -> Path:
 
 
 def review_assist_rollup_session_json_path(project_root: Path, stamp: str | None = None) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-rollup-{stamp or report_stamp()}.json"
+    return (
+        project_root.resolve() / "reports" / f"review-assist-rollup-{stamp or report_stamp()}.json"
+    )
 
 
 def review_assist_rollup_session_markdown_path(
@@ -1008,13 +1083,21 @@ def review_assist_reject_stage_latest_markdown_path(project_root: Path) -> Path:
 def review_assist_reject_stage_session_json_path(
     project_root: Path, stamp: str | None = None
 ) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-reject-stage-{stamp or report_stamp()}.json"
+    return (
+        project_root.resolve()
+        / "reports"
+        / f"review-assist-reject-stage-{stamp or report_stamp()}.json"
+    )
 
 
 def review_assist_reject_stage_session_markdown_path(
     project_root: Path, stamp: str | None = None
 ) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-reject-stage-{stamp or report_stamp()}.md"
+    return (
+        project_root.resolve()
+        / "reports"
+        / f"review-assist-reject-stage-{stamp or report_stamp()}.md"
+    )
 
 
 def review_assist_packet_hydrate_latest_json_path(project_root: Path) -> Path:
@@ -1028,13 +1111,21 @@ def review_assist_packet_hydrate_latest_markdown_path(project_root: Path) -> Pat
 def review_assist_packet_hydrate_session_json_path(
     project_root: Path, stamp: str | None = None
 ) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-packet-hydrate-{stamp or report_stamp()}.json"
+    return (
+        project_root.resolve()
+        / "reports"
+        / f"review-assist-packet-hydrate-{stamp or report_stamp()}.json"
+    )
 
 
 def review_assist_packet_hydrate_session_markdown_path(
     project_root: Path, stamp: str | None = None
 ) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-packet-hydrate-{stamp or report_stamp()}.md"
+    return (
+        project_root.resolve()
+        / "reports"
+        / f"review-assist-packet-hydrate-{stamp or report_stamp()}.md"
+    )
 
 
 def review_assist_scoreboard_latest_json_path(project_root: Path) -> Path:
@@ -1048,13 +1139,21 @@ def review_assist_scoreboard_latest_markdown_path(project_root: Path) -> Path:
 def review_assist_scoreboard_session_json_path(
     project_root: Path, stamp: str | None = None
 ) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-scoreboard-{stamp or report_stamp()}.json"
+    return (
+        project_root.resolve()
+        / "reports"
+        / f"review-assist-scoreboard-{stamp or report_stamp()}.json"
+    )
 
 
 def review_assist_scoreboard_session_markdown_path(
     project_root: Path, stamp: str | None = None
 ) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-scoreboard-{stamp or report_stamp()}.md"
+    return (
+        project_root.resolve()
+        / "reports"
+        / f"review-assist-scoreboard-{stamp or report_stamp()}.md"
+    )
 
 
 def review_assist_apply_plan_latest_json_path(project_root: Path) -> Path:
@@ -1068,13 +1167,21 @@ def review_assist_apply_plan_latest_markdown_path(project_root: Path) -> Path:
 def review_assist_apply_plan_session_json_path(
     project_root: Path, stamp: str | None = None
 ) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-apply-plan-{stamp or report_stamp()}.json"
+    return (
+        project_root.resolve()
+        / "reports"
+        / f"review-assist-apply-plan-{stamp or report_stamp()}.json"
+    )
 
 
 def review_assist_apply_plan_session_markdown_path(
     project_root: Path, stamp: str | None = None
 ) -> Path:
-    return project_root.resolve() / "reports" / f"review-assist-apply-plan-{stamp or report_stamp()}.md"
+    return (
+        project_root.resolve()
+        / "reports"
+        / f"review-assist-apply-plan-{stamp or report_stamp()}.md"
+    )
 
 
 def review_assist_report_path(
@@ -1084,7 +1191,9 @@ def review_assist_report_path(
     batch_id: str | None = None,
 ) -> Path:
     suffix = f"-{batch_id}" if batch_id else ""
-    return project_root.resolve() / "reports" / f"review-assist-{date_str or report_date()}{suffix}.md"
+    return (
+        project_root.resolve() / "reports" / f"review-assist-{date_str or report_date()}{suffix}.md"
+    )
 
 
 def render_entity_alias_review_checklist(payload: dict[str, Any]) -> str:
@@ -1192,7 +1301,11 @@ def _normalize_sample_manual_outcome(value: str) -> str:
         "skip": "pending",
     }
     for prefix, outcome in outcome_map.items():
-        if normalized == prefix or normalized.startswith(prefix + " ") or normalized.startswith(prefix + ":"):
+        if (
+            normalized == prefix
+            or normalized.startswith(prefix + " ")
+            or normalized.startswith(prefix + ":")
+        ):
             return outcome
     return normalized
 
@@ -1234,7 +1347,9 @@ def parse_entity_alias_review_sample_text(text: str, *, source_path: str) -> dic
                 current_sample["manual_outcome_raw"] = value.strip()
                 continue
             if key.strip() in {"Flags", "Labels", "Review IDs"}:
-                current_sample[normalized_key] = [part.strip() for part in value.split(",") if part.strip()]
+                current_sample[normalized_key] = [
+                    part.strip() for part in value.split(",") if part.strip()
+                ]
                 continue
             current_sample[normalized_key] = value.strip()
             continue
@@ -1468,7 +1583,9 @@ def _assistant_outcome_for_review_sample(sample: dict[str, Any]) -> tuple[str, s
         if "all-zero-overlap" in flags:
             reasons.append("Lexical overlap is absent across the sampled pairs.")
         if "has-low-specificity-labels" in flags:
-            reasons.append("At least one label looks like a heading, fragment, placeholder, or extraction residue.")
+            reasons.append(
+                "At least one label looks like a heading, fragment, placeholder, or extraction residue."
+            )
         if "has-high-score-disjoint-pairs" in flags:
             reasons.append("Queue score is still high, so contextual inspection remains warranted.")
             return "needs-context", "medium", reasons
@@ -1480,7 +1597,9 @@ def _assistant_outcome_for_review_sample(sample: dict[str, Any]) -> tuple[str, s
     if bucket == "alias-check":
         reasons.append("Lexical overlap is strong enough that rejection is not the safe default.")
         return "keep", "medium", reasons
-    reasons.append("Mixed signals remain; default to contextual review rather than automatic rejection.")
+    reasons.append(
+        "Mixed signals remain; default to contextual review rather than automatic rejection."
+    )
     return "needs-context", "low", reasons
 
 
@@ -1536,12 +1655,20 @@ def _compare_entity_alias_review_sample_summary_to_proposal(
     sample_path: str,
     proposal_path: str,
 ) -> dict[str, Any]:
-    sample_map = {_review_sample_key(sample): sample for sample in sample_summary.get("samples", [])}
-    proposal_map = {_review_sample_key(sample): sample for sample in proposal_payload.get("samples", [])}
+    sample_map = {
+        _review_sample_key(sample): sample for sample in sample_summary.get("samples", [])
+    }
+    proposal_map = {
+        _review_sample_key(sample): sample for sample in proposal_payload.get("samples", [])
+    }
 
     matched_keys = [key for key in sample_map if key in proposal_map]
-    unmatched_manual = [sample_map[key].get("anchor", key) for key in sample_map if key not in proposal_map]
-    unmatched_proposal = [proposal_map[key].get("anchor", key) for key in proposal_map if key not in sample_map]
+    unmatched_manual = [
+        sample_map[key].get("anchor", key) for key in sample_map if key not in proposal_map
+    ]
+    unmatched_proposal = [
+        proposal_map[key].get("anchor", key) for key in proposal_map if key not in sample_map
+    ]
 
     adjudicated_count = 0
     comparable_count = 0
@@ -1613,9 +1740,9 @@ def _compare_entity_alias_review_sample_summary_to_proposal(
                 summary["proposal_reject_hits"] = int(summary["proposal_reject_hits"]) + 1
             elif manual_outcome == "keep":
                 proposal_reject_false_positives += 1
-                summary["proposal_reject_false_positives"] = int(
-                    summary["proposal_reject_false_positives"]
-                ) + 1
+                summary["proposal_reject_false_positives"] = (
+                    int(summary["proposal_reject_false_positives"]) + 1
+                )
 
     for summary in confidence_summary.values():
         reject_count = int(summary["proposal_reject_hits"]) + int(
@@ -1626,7 +1753,9 @@ def _compare_entity_alias_review_sample_summary_to_proposal(
 
     agreement_rate = round(agreement_count / comparable_count, 4) if comparable_count else None
     reject_denominator = proposal_reject_hits + proposal_reject_false_positives
-    reject_precision = round(proposal_reject_hits / reject_denominator, 4) if reject_denominator else None
+    reject_precision = (
+        round(proposal_reject_hits / reject_denominator, 4) if reject_denominator else None
+    )
     return {
         "generated_at": now_iso(),
         "sample_path": sample_path,
@@ -1652,7 +1781,9 @@ def _compare_entity_alias_review_sample_summary_to_proposal(
     }
 
 
-def compare_entity_alias_review_sample_to_proposal(sample_path: Path, proposal_path: Path) -> dict[str, Any]:
+def compare_entity_alias_review_sample_to_proposal(
+    sample_path: Path, proposal_path: Path
+) -> dict[str, Any]:
     sample_summary = summarize_entity_alias_review_sample(sample_path)
     proposal_payload = load_entity_alias_review_sample_proposal(proposal_path)
     return _compare_entity_alias_review_sample_summary_to_proposal(
@@ -1688,7 +1819,8 @@ def render_entity_alias_review_sample_summary(payload: dict[str, Any]) -> str:
         bucket_line = ", ".join(
             f"{bucket}={summary['group_count']}"
             for bucket, summary in sorted(
-                payload["bucket_summary"].items(), key=lambda item: (-item[1]["group_count"], item[0])
+                payload["bucket_summary"].items(),
+                key=lambda item: (-item[1]["group_count"], item[0]),
             )
         )
         lines.append(f"Buckets: {bucket_line}")
@@ -1771,7 +1903,8 @@ def render_entity_alias_review_sample_comparison(payload: dict[str, Any]) -> str
         confidence_line = ", ".join(
             f"{level}={summary['count']}"
             for level, summary in sorted(
-                payload["confidence_summary"].items(), key=lambda item: (-int(item[1]["count"]), item[0])
+                payload["confidence_summary"].items(),
+                key=lambda item: (-int(item[1]["count"]), item[0]),
             )
         )
         lines.append(f"Confidence: {confidence_line}")
@@ -1910,13 +2043,17 @@ def _campaign_scenarios(
 ) -> list[dict[str, Any]]:
     if scenarios is not None:
         return [{**scenario} for scenario in scenarios]
-    catalog = {entry["label"]: {**entry} for entry in STANDARD_ENTITY_ALIAS_REVIEW_CAMPAIGN_SCENARIOS}
+    catalog = {
+        entry["label"]: {**entry} for entry in STANDARD_ENTITY_ALIAS_REVIEW_CAMPAIGN_SCENARIOS
+    }
     if not scenario_labels:
         return list(catalog.values())
     unknown = [label for label in scenario_labels if label not in catalog]
     if unknown:
         available = ", ".join(sorted(catalog))
-        raise ValueError(f"Unknown review campaign scenario(s): {', '.join(sorted(set(unknown)))}. Available scenarios: {available}")
+        raise ValueError(
+            f"Unknown review campaign scenario(s): {', '.join(sorted(set(unknown)))}. Available scenarios: {available}"
+        )
     selected: list[dict[str, Any]] = []
     seen: set[str] = set()
     for label in scenario_labels:
@@ -1950,7 +2087,11 @@ def _sample_packet_id_from_path(path: Path) -> str | None:
     suffix = name[len(prefix) : -3]
     if not suffix or suffix == "latest":
         return None
-    if suffix.startswith("summary-") or suffix.startswith("proposal-") or suffix.startswith("compare-"):
+    if (
+        suffix.startswith("summary-")
+        or suffix.startswith("proposal-")
+        or suffix.startswith("compare-")
+    ):
         return None
     return suffix
 
@@ -2147,7 +2288,9 @@ def build_entity_alias_review_campaign(
         "generated_at": now_iso(),
         "project_root": str(project_root.resolve()),
         "batch_size": batch_size,
-        "available_scenarios": [entry["label"] for entry in STANDARD_ENTITY_ALIAS_REVIEW_CAMPAIGN_SCENARIOS],
+        "available_scenarios": [
+            entry["label"] for entry in STANDARD_ENTITY_ALIAS_REVIEW_CAMPAIGN_SCENARIOS
+        ],
         "selected_scenarios": [scenario["label"] for scenario in selected_scenarios],
         "scenario_count": len(scenario_payloads),
         "sampled_group_count": sampled_group_count,
@@ -2200,7 +2343,9 @@ def render_entity_alias_review_campaign(payload: dict[str, Any]) -> str:
         proposal_payload = scenario.get("proposal_payload") or {}
         comparison_payload = scenario.get("comparison_payload") or {}
         scenario_precision = comparison_payload.get("proposal_reject_precision")
-        scenario_precision_text = "n/a" if scenario_precision is None else f"{scenario_precision:.2%}"
+        scenario_precision_text = (
+            "n/a" if scenario_precision is None else f"{scenario_precision:.2%}"
+        )
         lines.append(f"- {scenario['label']}: {scenario.get('description', '')}")
         lines.append(
             "  sample: "
@@ -2227,9 +2372,15 @@ def render_entity_alias_review_campaign(payload: dict[str, Any]) -> str:
             f"reject_precision={scenario_precision_text}"
         )
         if scenario.get("artifacts"):
-            lines.append(f"  sample_artifact: {scenario['artifacts']['sample']['session_markdown_path']}")
-            lines.append(f"  proposal_artifact: {scenario['artifacts']['proposal']['session_markdown_path']}")
-            lines.append(f"  compare_artifact: {scenario['artifacts']['comparison']['session_markdown_path']}")
+            lines.append(
+                f"  sample_artifact: {scenario['artifacts']['sample']['session_markdown_path']}"
+            )
+            lines.append(
+                f"  proposal_artifact: {scenario['artifacts']['proposal']['session_markdown_path']}"
+            )
+            lines.append(
+                f"  compare_artifact: {scenario['artifacts']['comparison']['session_markdown_path']}"
+            )
         lines.append("")
     return "\n".join(lines).rstrip()
 
@@ -2324,8 +2475,12 @@ def build_entity_alias_review_campaign_index(project_root: Path) -> dict[str, An
         packet_record = {
             "packet_id": packet_id,
             "sample_path": sample_key,
-            "proposal_path": proposal_entry["artifact_path"] if proposal_entry is not None else None,
-            "compare_path": comparison_entry["artifact_path"] if comparison_entry is not None else None,
+            "proposal_path": proposal_entry["artifact_path"]
+            if proposal_entry is not None
+            else None,
+            "compare_path": comparison_entry["artifact_path"]
+            if comparison_entry is not None
+            else None,
             "scenario_label": scenario_label,
             "status": packet_status,
             "total_samples": hydration_payload.get("total_samples", 0),
@@ -2370,8 +2525,8 @@ def build_entity_alias_review_campaign_index(project_root: Path) -> dict[str, An
         packet_ids: list[str] = []
         packet_paths: list[str] = []
         for scenario in payload.get("scenarios", []):
-            sample_path = (
-                ((scenario.get("artifacts") or {}).get("sample") or {}).get("session_markdown_path")
+            sample_path = ((scenario.get("artifacts") or {}).get("sample") or {}).get(
+                "session_markdown_path"
             )
             if not sample_path:
                 continue
@@ -2594,9 +2749,13 @@ def build_entity_alias_review_rollup(
     proposal_reject_false_positives = 0
 
     for packet in selected_packets:
-        selected_status_counts[packet["status"]] = selected_status_counts.get(packet["status"], 0) + 1
+        selected_status_counts[packet["status"]] = (
+            selected_status_counts.get(packet["status"], 0) + 1
+        )
         scenario_label = packet.get("scenario_label") or "legacy"
-        selected_scenario_counts[scenario_label] = selected_scenario_counts.get(scenario_label, 0) + 1
+        selected_scenario_counts[scenario_label] = (
+            selected_scenario_counts.get(scenario_label, 0) + 1
+        )
 
     for packet in compared_packets:
         comparison_payload = _load_json_artifact(Path(packet["compare_path"]))
@@ -2607,7 +2766,9 @@ def build_entity_alias_review_rollup(
         disagreement_count += int(comparison_payload.get("disagreement_count") or 0)
         proposal_reject_count += int(comparison_payload.get("proposal_reject_count") or 0)
         proposal_keep_count += int(comparison_payload.get("proposal_keep_count") or 0)
-        proposal_needs_context_count += int(comparison_payload.get("proposal_needs_context_count") or 0)
+        proposal_needs_context_count += int(
+            comparison_payload.get("proposal_needs_context_count") or 0
+        )
         proposal_reject_hits += int(comparison_payload.get("proposal_reject_hits") or 0)
         proposal_reject_false_positives += int(
             comparison_payload.get("proposal_reject_false_positives") or 0
@@ -2649,7 +2810,9 @@ def build_entity_alias_review_rollup(
 
     agreement_rate = round(agreement_count / comparable_count, 4) if comparable_count else None
     reject_denominator = proposal_reject_hits + proposal_reject_false_positives
-    reject_precision = round(proposal_reject_hits / reject_denominator, 4) if reject_denominator else None
+    reject_precision = (
+        round(proposal_reject_hits / reject_denominator, 4) if reject_denominator else None
+    )
     return {
         "generated_at": now_iso(),
         "project_root": str(project_root.resolve()),
@@ -2722,7 +2885,8 @@ def render_entity_alias_review_rollup(payload: dict[str, Any]) -> str:
         confidence_line = ", ".join(
             f"{level}={summary['count']}"
             for level, summary in sorted(
-                payload["confidence_summary"].items(), key=lambda item: (-int(item[1]["count"]), item[0])
+                payload["confidence_summary"].items(),
+                key=lambda item: (-int(item[1]["count"]), item[0]),
             )
         )
         lines.append(f"Confidence: {confidence_line}")
@@ -2786,7 +2950,9 @@ def build_entity_alias_reject_stage(
             f"Need at least {min_adjudicated} adjudicated samples; found {adjudicated_count}."
         )
     if precision is None:
-        blocked_reasons.append("Proposal reject precision is not yet measurable for the selected packets.")
+        blocked_reasons.append(
+            "Proposal reject precision is not yet measurable for the selected packets."
+        )
     elif precision < min_reject_precision:
         blocked_reasons.append(
             f"Proposal reject precision {precision:.2%} is below the required {min_reject_precision:.2%}."
@@ -2968,7 +3134,9 @@ def build_entity_alias_review_scoreboard(
                 "warning_count": packet.get("warning_count", 0),
                 "priority_bucket": priority_bucket,
                 "priority_score": priority_score,
-                "remaining_to_threshold_after_completion": max(0, remaining_to_threshold - pending_samples),
+                "remaining_to_threshold_after_completion": max(
+                    0, remaining_to_threshold - pending_samples
+                ),
             }
         )
     ranked_packets.sort(
@@ -3140,10 +3308,14 @@ def render_entity_alias_review_apply_plan(payload: dict[str, Any]) -> str:
             lines.append(f"- {reason}")
     lines.append("Snapshots:")
     for entry in payload.get("snapshot_contract", {}).get("pre_apply_snapshots", []):
-        lines.append(f"- {entry['label']}: {entry['source_path']} -> {entry['planned_snapshot_path']}")
+        lines.append(
+            f"- {entry['label']}: {entry['source_path']} -> {entry['planned_snapshot_path']}"
+        )
     lines.append("Rollback:")
-    for step in payload.get("snapshot_contract", {}).get("rollback_contract", {}).get(
-        "post_restore_steps", []
+    for step in (
+        payload.get("snapshot_contract", {})
+        .get("rollback_contract", {})
+        .get("post_restore_steps", [])
     ):
         lines.append(f"- {step}")
     return "\n".join(lines).rstrip()

--- a/tests/test_answering.py
+++ b/tests/test_answering.py
@@ -109,9 +109,7 @@ def _seed_answer_corpus(root: Path) -> Path:
                         "canonical_question": "How should alpha governance evolve?",
                     }
                 ],
-                "key_entities": [
-                    {"canonical_label": "Alpha Engine", "entity_type": "concept"}
-                ],
+                "key_entities": [{"canonical_label": "Alpha Engine", "entity_type": "concept"}],
                 "vector_terms": {"registry": 1.0, "governance": 0.85, "ritual": 0.7},
             }
         ],

--- a/tests/test_chatgpt_local_session.py
+++ b/tests/test_chatgpt_local_session.py
@@ -200,7 +200,9 @@ def test_resolve_chatgpt_cookie_jar_validates_existence_and_magic(tmp_path: Path
         module.resolve_chatgpt_cookie_jar(bad)
 
     good = tmp_path / "good.binarycookies"
-    good.write_bytes(build_binary_cookie_jar([{"domain": ".chatgpt.com", "name": "x", "value": "y"}]))
+    good.write_bytes(
+        build_binary_cookie_jar([{"domain": ".chatgpt.com", "name": "x", "value": "y"}])
+    )
     assert module.resolve_chatgpt_cookie_jar(good) == good.resolve()
 
 

--- a/tests/test_claude_local_session.py
+++ b/tests/test_claude_local_session.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import sqlite3
 import sys
 from pathlib import Path

--- a/tests/test_claude_local_session.py
+++ b/tests/test_claude_local_session.py
@@ -102,7 +102,9 @@ def test_decrypt_chromium_cookie_raises_for_openssl_error(monkeypatch: pytest.Mo
         module.decrypt_chromium_cookie(b"v10ciphertext", module.CLAUDE_COOKIE_HOST, "secret")
 
 
-def test_decrypt_chromium_cookie_raises_for_invalid_padding(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_decrypt_chromium_cookie_raises_for_invalid_padding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(
         module.subprocess,
         "run",
@@ -113,7 +115,9 @@ def test_decrypt_chromium_cookie_raises_for_invalid_padding(monkeypatch: pytest.
         module.decrypt_chromium_cookie(b"v10ciphertext", module.CLAUDE_COOKIE_HOST, "secret")
 
 
-def test_load_cookie_value_prefers_plain_value_and_can_decrypt(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_cookie_value_prefers_plain_value_and_can_decrypt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     connection = sqlite3.connect(":memory:")
     try:
         connection.execute(
@@ -217,7 +221,9 @@ def test_fetch_json_uses_cookie_header(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(module, "urlopen", fake_urlopen)
 
     payload = module.fetch_json(
-        module.ClaudeHttpSession(headers={"Accept": "application/json"}, cookie_header="sessionKey=abc"),
+        module.ClaudeHttpSession(
+            headers={"Accept": "application/json"}, cookie_header="sessionKey=abc"
+        ),
         "https://claude.ai/api/test",
     )
 
@@ -227,14 +233,18 @@ def test_fetch_json_uses_cookie_header(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_fetch_claude_bootstrap_requires_object(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(module, "fetch_json", lambda session, url: [])
 
-    with pytest.raises(module.ClaudeLocalSessionError, match="bootstrap payload was not a JSON object"):
+    with pytest.raises(
+        module.ClaudeLocalSessionError, match="bootstrap payload was not a JSON object"
+    ):
         module.fetch_claude_bootstrap(module.ClaudeHttpSession(headers={}, cookie_header=""))
 
 
 def test_discover_claude_local_session_assembles_summary(monkeypatch: pytest.MonkeyPatch) -> None:
     local_root = Path("/tmp/claude")
     monkeypatch.setattr(module, "resolve_claude_local_root", lambda path: local_root)
-    monkeypatch.setattr(module, "find_safe_storage_password", lambda: ("Claude Safe Storage", "secret"))
+    monkeypatch.setattr(
+        module, "find_safe_storage_password", lambda: ("Claude Safe Storage", "secret")
+    )
     monkeypatch.setattr(
         module,
         "load_claude_cookies",
@@ -283,7 +293,9 @@ def test_fetch_claude_local_session_bundle_collects_details_and_failures(
 ) -> None:
     local_root = Path("/tmp/claude")
     monkeypatch.setattr(module, "resolve_claude_local_root", lambda path: local_root)
-    monkeypatch.setattr(module, "find_safe_storage_password", lambda: ("Claude Safe Storage", "secret"))
+    monkeypatch.setattr(
+        module, "find_safe_storage_password", lambda: ("Claude Safe Storage", "secret")
+    )
     monkeypatch.setattr(
         module,
         "load_claude_cookies",
@@ -366,7 +378,9 @@ def test_delta_aware_fetch_reuses_cached_conversations(
     local_root = Path("/tmp/claude")
     output_root = tmp_path / "output"
     monkeypatch.setattr(module, "resolve_claude_local_root", lambda path: local_root)
-    monkeypatch.setattr(module, "find_safe_storage_password", lambda: ("Claude Safe Storage", "secret"))
+    monkeypatch.setattr(
+        module, "find_safe_storage_password", lambda: ("Claude Safe Storage", "secret")
+    )
     monkeypatch.setattr(
         module,
         "load_claude_cookies",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -340,7 +340,9 @@ def test_main_review_assist_renders_text_summary(
         "render_entity_alias_review_assist",
         lambda data, *, group_limit: f"assist for {data['open_count']} with limit {group_limit}",
     )
-    monkeypatch.setattr(MODULE, "select_entity_alias_review_assist_batch", lambda payload, batch_id: payload)
+    monkeypatch.setattr(
+        MODULE, "select_entity_alias_review_assist_batch", lambda payload, batch_id: payload
+    )
 
     _run_main(
         monkeypatch,
@@ -381,9 +383,13 @@ def test_main_review_assist_json_mode_prints_payload(
     monkeypatch.setattr(
         MODULE,
         "write_entity_alias_review_assist_artifacts",
-        lambda project_root, payload: {"latest_json_path": str(project_root / "reports" / "assist.json")},
+        lambda project_root, payload: {
+            "latest_json_path": str(project_root / "reports" / "assist.json")
+        },
     )
-    monkeypatch.setattr(MODULE, "select_entity_alias_review_assist_batch", lambda payload, batch_id: payload)
+    monkeypatch.setattr(
+        MODULE, "select_entity_alias_review_assist_batch", lambda payload, batch_id: payload
+    )
 
     _run_main(
         monkeypatch,
@@ -427,7 +433,9 @@ def test_main_review_assist_text_mode_prints_artifact_paths_when_written(
             "report_path": str(project_root / "reports" / "assist-2026-03-25.md"),
         },
     )
-    monkeypatch.setattr(MODULE, "select_entity_alias_review_assist_batch", lambda payload, batch_id: payload)
+    monkeypatch.setattr(
+        MODULE, "select_entity_alias_review_assist_batch", lambda payload, batch_id: payload
+    )
 
     _run_main(monkeypatch, ["review", "assist", "--project-root", str(tmp_path), "--write"])
     output = capsys.readouterr().out
@@ -444,10 +452,15 @@ def test_main_review_assist_batch_id_selects_single_batch(
     monkeypatch.setattr(
         MODULE,
         "build_entity_alias_review_assist",
-        lambda project_root, **kwargs: {"open_count": 4, "batches": [{"batch_id": "entity-alias-batch-001"}]},
+        lambda project_root, **kwargs: {
+            "open_count": 4,
+            "batches": [{"batch_id": "entity-alias-batch-001"}],
+        },
     )
 
-    def fake_select_review_assist_batch(payload: dict[str, object], batch_id: str) -> dict[str, object]:
+    def fake_select_review_assist_batch(
+        payload: dict[str, object], batch_id: str
+    ) -> dict[str, object]:
         calls["select"] = (payload, batch_id)
         return {"open_count": 2, "selection": {"batch_id": batch_id}}
 
@@ -459,9 +472,15 @@ def test_main_review_assist_batch_id_selects_single_batch(
     monkeypatch.setattr(
         MODULE,
         "render_entity_alias_review_assist",
-        lambda payload, *, group_limit: f"batch {payload['selection']['batch_id']} limit {group_limit}",
+        lambda payload, *, group_limit: (
+            f"batch {payload['selection']['batch_id']} limit {group_limit}"
+        ),
     )
-    monkeypatch.setattr(MODULE, "filter_entity_alias_review_assist_groups", lambda payload, review_bucket_filters=None: payload)
+    monkeypatch.setattr(
+        MODULE,
+        "filter_entity_alias_review_assist_groups",
+        lambda payload, review_bucket_filters=None: payload,
+    )
 
     _run_main(
         monkeypatch,
@@ -486,14 +505,21 @@ def test_main_review_assist_invalid_batch_id_exits_via_parser(
     monkeypatch.setattr(
         MODULE,
         "build_entity_alias_review_assist",
-        lambda project_root, **kwargs: {"open_count": 4, "batches": [{"batch_id": "entity-alias-batch-001"}]},
+        lambda project_root, **kwargs: {
+            "open_count": 4,
+            "batches": [{"batch_id": "entity-alias-batch-001"}],
+        },
     )
     monkeypatch.setattr(
         MODULE,
         "select_entity_alias_review_assist_batch",
         lambda payload, batch_id: (_ for _ in ()).throw(ValueError(f"Unknown batch: {batch_id}")),
     )
-    monkeypatch.setattr(MODULE, "filter_entity_alias_review_assist_groups", lambda payload, review_bucket_filters=None: payload)
+    monkeypatch.setattr(
+        MODULE,
+        "filter_entity_alias_review_assist_groups",
+        lambda payload, review_bucket_filters=None: payload,
+    )
 
     with pytest.raises(SystemExit) as exc_info:
         _run_main(
@@ -520,7 +546,9 @@ def test_main_review_assist_sample_mode_filters_groups_and_writes_sample_artifac
         "build_entity_alias_review_assist",
         lambda project_root, **kwargs: {"open_count": 8, "groups": [], "batches": []},
     )
-    monkeypatch.setattr(MODULE, "select_entity_alias_review_assist_batch", lambda payload, batch_id: payload)
+    monkeypatch.setattr(
+        MODULE, "select_entity_alias_review_assist_batch", lambda payload, batch_id: payload
+    )
 
     def fake_filter_review_assist_groups(
         payload: dict[str, object],
@@ -544,9 +572,15 @@ def test_main_review_assist_sample_mode_filters_groups_and_writes_sample_artifac
             "sample": {"selected_group_count": 2},
         }
 
-    monkeypatch.setattr(MODULE, "filter_entity_alias_review_assist_groups", fake_filter_review_assist_groups)
-    monkeypatch.setattr(MODULE, "sample_entity_alias_review_assist_groups", fake_sample_review_assist_groups)
-    monkeypatch.setattr(MODULE, "render_entity_alias_review_sample", lambda payload: "sample report")
+    monkeypatch.setattr(
+        MODULE, "filter_entity_alias_review_assist_groups", fake_filter_review_assist_groups
+    )
+    monkeypatch.setattr(
+        MODULE, "sample_entity_alias_review_assist_groups", fake_sample_review_assist_groups
+    )
+    monkeypatch.setattr(
+        MODULE, "render_entity_alias_review_sample", lambda payload: "sample report"
+    )
     monkeypatch.setattr(
         MODULE,
         "write_entity_alias_review_sample_artifacts",
@@ -588,10 +622,20 @@ def test_main_review_assist_sample_json_mode_prints_sample_payload(
     monkeypatch.setattr(
         MODULE,
         "build_entity_alias_review_assist",
-        lambda project_root, **kwargs: {"project_root": str(project_root), "groups": [], "batches": []},
+        lambda project_root, **kwargs: {
+            "project_root": str(project_root),
+            "groups": [],
+            "batches": [],
+        },
     )
-    monkeypatch.setattr(MODULE, "select_entity_alias_review_assist_batch", lambda payload, batch_id: payload)
-    monkeypatch.setattr(MODULE, "filter_entity_alias_review_assist_groups", lambda payload, review_bucket_filters=None: payload)
+    monkeypatch.setattr(
+        MODULE, "select_entity_alias_review_assist_batch", lambda payload, batch_id: payload
+    )
+    monkeypatch.setattr(
+        MODULE,
+        "filter_entity_alias_review_assist_groups",
+        lambda payload, review_bucket_filters=None: payload,
+    )
     monkeypatch.setattr(
         MODULE,
         "sample_entity_alias_review_assist_groups",
@@ -607,7 +651,9 @@ def test_main_review_assist_sample_json_mode_prints_sample_payload(
     monkeypatch.setattr(
         MODULE,
         "write_entity_alias_review_sample_artifacts",
-        lambda project_root, payload: {"latest_markdown_path": str(project_root / "reports" / "sample-latest.md")},
+        lambda project_root, payload: {
+            "latest_markdown_path": str(project_root / "reports" / "sample-latest.md")
+        },
     )
 
     _run_main(
@@ -651,7 +697,9 @@ def test_main_review_sample_summary_renders_text_and_artifacts(
         calls["write"] = (project_root, payload)
         return {"latest_markdown_path": str(project_root / "reports" / "sample-summary-latest.md")}
 
-    monkeypatch.setattr(MODULE, "summarize_entity_alias_review_sample", fake_summarize_review_sample)
+    monkeypatch.setattr(
+        MODULE, "summarize_entity_alias_review_sample", fake_summarize_review_sample
+    )
     monkeypatch.setattr(
         MODULE,
         "render_entity_alias_review_sample_summary",
@@ -678,7 +726,10 @@ def test_main_review_sample_summary_renders_text_and_artifacts(
     output = capsys.readouterr().out
 
     assert calls["summarize"] == sample_path
-    assert calls["write"] == (tmp_path, {"source_path": str(sample_path), "reject_precision": 0.75, "samples": []})
+    assert calls["write"] == (
+        tmp_path,
+        {"source_path": str(sample_path), "reject_precision": 0.75, "samples": []},
+    )
     assert "summary for" in output
     assert str(tmp_path / "reports" / "sample-summary-latest.md") in output
 
@@ -695,7 +746,9 @@ def test_main_review_sample_summary_json_mode_prints_payload(
     monkeypatch.setattr(
         MODULE,
         "write_entity_alias_review_sample_summary_artifacts",
-        lambda project_root, payload: {"latest_json_path": str(project_root / "reports" / "sample-summary-latest.json")},
+        lambda project_root, payload: {
+            "latest_json_path": str(project_root / "reports" / "sample-summary-latest.json")
+        },
     )
 
     _run_main(
@@ -776,12 +829,18 @@ def test_main_review_sample_propose_json_mode_prints_payload(
     monkeypatch.setattr(
         MODULE,
         "propose_entity_alias_review_sample",
-        lambda path: {"source_path": str(path), "assistant_outcome_counts": {"reject": 2}, "samples": []},
+        lambda path: {
+            "source_path": str(path),
+            "assistant_outcome_counts": {"reject": 2},
+            "samples": [],
+        },
     )
     monkeypatch.setattr(
         MODULE,
         "write_entity_alias_review_sample_proposal_artifacts",
-        lambda project_root, payload: {"latest_json_path": str(project_root / "reports" / "sample-proposal-latest.json")},
+        lambda project_root, payload: {
+            "latest_json_path": str(project_root / "reports" / "sample-proposal-latest.json")
+        },
     )
 
     _run_main(
@@ -821,7 +880,9 @@ def test_main_review_sample_compare_renders_text_and_artifacts(
         calls["write"] = (project_root, payload)
         return {"latest_markdown_path": str(project_root / "reports" / "sample-compare-latest.md")}
 
-    monkeypatch.setattr(MODULE, "compare_entity_alias_review_sample_to_proposal", fake_compare_review_sample)
+    monkeypatch.setattr(
+        MODULE, "compare_entity_alias_review_sample_to_proposal", fake_compare_review_sample
+    )
     monkeypatch.setattr(
         MODULE,
         "render_entity_alias_review_sample_comparison",
@@ -852,7 +913,11 @@ def test_main_review_sample_compare_renders_text_and_artifacts(
     assert calls["compare"] == (sample_path, proposal_path)
     assert calls["write"] == (
         tmp_path,
-        {"sample_path": str(sample_path), "proposal_path": str(proposal_path), "agreement_rate": 0.75},
+        {
+            "sample_path": str(sample_path),
+            "proposal_path": str(proposal_path),
+            "agreement_rate": 0.75,
+        },
     )
     assert "comparison for" in output
     assert str(tmp_path / "reports" / "sample-compare-latest.md") in output
@@ -866,12 +931,18 @@ def test_main_review_sample_compare_json_mode_prints_payload(
     monkeypatch.setattr(
         MODULE,
         "compare_entity_alias_review_sample_to_proposal",
-        lambda sample, proposal: {"sample_path": str(sample), "proposal_path": str(proposal), "agreement_rate": 0.5},
+        lambda sample, proposal: {
+            "sample_path": str(sample),
+            "proposal_path": str(proposal),
+            "agreement_rate": 0.5,
+        },
     )
     monkeypatch.setattr(
         MODULE,
         "write_entity_alias_review_sample_comparison_artifacts",
-        lambda project_root, payload: {"latest_json_path": str(project_root / "reports" / "sample-compare-latest.json")},
+        lambda project_root, payload: {
+            "latest_json_path": str(project_root / "reports" / "sample-compare-latest.json")
+        },
     )
 
     _run_main(
@@ -1027,7 +1098,9 @@ def test_main_review_campaign_index_renders_text_and_artifacts(
         calls["write"] = (project_root, payload)
         return {"latest_markdown_path": str(project_root / "reports" / "campaign-index-latest.md")}
 
-    monkeypatch.setattr(MODULE, "build_entity_alias_review_campaign_index", fake_build_campaign_index)
+    monkeypatch.setattr(
+        MODULE, "build_entity_alias_review_campaign_index", fake_build_campaign_index
+    )
     monkeypatch.setattr(
         MODULE,
         "render_entity_alias_review_campaign_index",
@@ -1080,7 +1153,9 @@ def test_main_review_campaign_rollup_json_mode_prints_payload(
     monkeypatch.setattr(
         MODULE,
         "write_entity_alias_review_rollup_artifacts",
-        lambda project_root, payload: {"latest_json_path": str(project_root / "reports" / "rollup-latest.json")},
+        lambda project_root, payload: {
+            "latest_json_path": str(project_root / "reports" / "rollup-latest.json")
+        },
     )
 
     _run_main(
@@ -1210,7 +1285,9 @@ def test_main_review_packet_hydrate_json_mode_prints_payload(
     monkeypatch.setattr(
         MODULE,
         "write_entity_alias_review_packet_hydration_artifacts",
-        lambda project_root, payload: {"latest_json_path": str(project_root / "reports" / "packet-hydrate-latest.json")},
+        lambda project_root, payload: {
+            "latest_json_path": str(project_root / "reports" / "packet-hydrate-latest.json")
+        },
     )
 
     _run_main(
@@ -1307,7 +1384,9 @@ def test_main_review_apply_plan_json_mode_prints_payload(
     monkeypatch.setattr(
         MODULE,
         "write_entity_alias_review_apply_plan_artifacts",
-        lambda project_root, payload: {"latest_json_path": str(project_root / "reports" / "apply-plan-latest.json")},
+        lambda project_root, payload: {
+            "latest_json_path": str(project_root / "reports" / "apply-plan-latest.json")
+        },
     )
 
     _run_main(
@@ -1371,7 +1450,9 @@ def test_main_dashboard_text_mode_uses_renderer_output(
     monkeypatch.setattr(
         MODULE,
         "render_dashboard_text",
-        lambda payload: f"dashboard for {payload['project_root']} via {payload['source_drop_root']}",
+        lambda payload: (
+            f"dashboard for {payload['project_root']} via {payload['source_drop_root']}"
+        ),
     )
 
     _run_main(

--- a/tests/test_federated_canon.py
+++ b/tests/test_federated_canon.py
@@ -61,12 +61,8 @@ def _surface(
                 "stable_themes": themes,
                 "doctrine_summary": f"{family_title} doctrine.",
                 "actions": [{"action_key": action_key, "canonical_action": action_text}],
-                "unresolved": [
-                    {"question_key": question_key, "canonical_question": question_text}
-                ],
-                "key_entities": [
-                    {"canonical_label": entity_label, "entity_type": "concept"}
-                ],
+                "unresolved": [{"question_key": question_key, "canonical_question": question_text}],
+                "key_entities": [{"canonical_label": entity_label, "entity_type": "concept"}],
             }
         ],
         "doctrine_briefs": [
@@ -523,9 +519,7 @@ class TestMigrateReviewIds:
         ]
         self._seed_state(tmp_path, items)
         MODULE.migrate_review_ids(tmp_path)
-        queue = json.loads(
-            (tmp_path / "state" / "federated-review-queue.json").read_text()
-        )
+        queue = json.loads((tmp_path / "state" / "federated-review-queue.json").read_text())
         new_ids = [i["review_id"] for i in queue["items"]]
         assert len(set(new_ids)) == 2, f"Expected unique IDs after migration, got {new_ids}"
 

--- a/tests/test_import_chatgpt_local_session_corpus.py
+++ b/tests/test_import_chatgpt_local_session_corpus.py
@@ -8,7 +8,6 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from conversation_corpus_engine import chatgpt_local_session  # noqa: E402
 from conversation_corpus_engine import import_chatgpt_local_session_corpus as module  # noqa: E402
 
 

--- a/tests/test_import_claude_local_session_corpus.py
+++ b/tests/test_import_claude_local_session_corpus.py
@@ -176,7 +176,9 @@ def test_import_claude_local_session_corpus_writes_metadata_and_returns_summary(
                         "created_at": "2026-03-25T00:00:00Z",
                         "updated_at": "2026-03-25T00:00:00Z",
                         "text": "Summarize the local session import.",
-                        "content": [{"type": "text", "text": "Summarize the local session import."}],
+                        "content": [
+                            {"type": "text", "text": "Summarize the local session import."}
+                        ],
                         "attachments": [],
                         "files": [],
                     },
@@ -200,9 +202,7 @@ def test_import_claude_local_session_corpus_writes_metadata_and_returns_summary(
         ],
     }
     monkeypatch.setattr(module, "discover_claude_local_session", lambda root: discovery)
-    monkeypatch.setattr(
-        module, "fetch_claude_local_session_bundle", lambda root, **kwargs: bundle
-    )
+    monkeypatch.setattr(module, "fetch_claude_local_session_bundle", lambda root, **kwargs: bundle)
 
     result = module.import_claude_local_session_corpus(local_root, output_root)
 

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -55,20 +55,24 @@ def test_get_provider_config_rejects_unknown_provider() -> None:
 
 
 def test_provider_bootstrap_report_path_uses_reports_directory(tmp_path: Path) -> None:
-    assert provider_bootstrap_report_path(tmp_path / "project", "claude") == (
-        tmp_path / "project" / "reports" / "claude-evaluation-bootstrap-latest.md"
-    ).resolve()
+    assert (
+        provider_bootstrap_report_path(tmp_path / "project", "claude")
+        == (tmp_path / "project" / "reports" / "claude-evaluation-bootstrap-latest.md").resolve()
+    )
 
 
 def test_conventional_corpus_root_uses_source_drop_parent(tmp_path: Path) -> None:
     source_drop_root = tmp_path / "source-drop"
 
-    assert conventional_corpus_root(source_drop_root, "chatgpt-history") == (
-        tmp_path / "chatgpt-history"
-    ).resolve()
+    assert (
+        conventional_corpus_root(source_drop_root, "chatgpt-history")
+        == (tmp_path / "chatgpt-history").resolve()
+    )
 
 
-def test_provider_corpus_targets_prefers_viable_fallback_when_primary_missing(tmp_path: Path) -> None:
+def test_provider_corpus_targets_prefers_viable_fallback_when_primary_missing(
+    tmp_path: Path,
+) -> None:
     project_root = tmp_path / "project"
     source_drop_root = tmp_path / "source-drop"
     fallback_root = tmp_path / "chatgpt-history"

--- a/tests/test_source_lifecycle.py
+++ b/tests/test_source_lifecycle.py
@@ -60,15 +60,13 @@ def test_collect_source_files_for_claude_local_session_tracks_only_supported_pat
     (local_root / "Local Storage" / "leveldb" / "0001.log").parent.mkdir(
         parents=True, exist_ok=True
     )
-    (local_root / "Local Storage" / "leveldb" / "0001.log").write_text(
-        "leveldb", encoding="utf-8"
+    (local_root / "Local Storage" / "leveldb" / "0001.log").write_text("leveldb", encoding="utf-8")
+    (local_root / "IndexedDB" / "https_claude.ai_0.indexeddb.leveldb" / "LOG").parent.mkdir(
+        parents=True, exist_ok=True
     )
-    (
-        local_root / "IndexedDB" / "https_claude.ai_0.indexeddb.leveldb" / "LOG"
-    ).parent.mkdir(parents=True, exist_ok=True)
-    (
-        local_root / "IndexedDB" / "https_claude.ai_0.indexeddb.leveldb" / "LOG"
-    ).write_text("indexeddb", encoding="utf-8")
+    (local_root / "IndexedDB" / "https_claude.ai_0.indexeddb.leveldb" / "LOG").write_text(
+        "indexeddb", encoding="utf-8"
+    )
     (local_root / "random" / "ignore.txt").parent.mkdir(parents=True, exist_ok=True)
     (local_root / "random" / "ignore.txt").write_text("ignore", encoding="utf-8")
 

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -195,9 +195,9 @@ class EntityAliasReviewCampaignTests(unittest.TestCase):
                 ),
                 patch(
                     "conversation_corpus_engine.triage.sample_entity_alias_review_assist_groups",
-                    side_effect=lambda payload, sample_groups, sample_batches=None, batch_offset=0: sample_payloads[
-                        str(payload["scenario_label"])
-                    ],
+                    side_effect=lambda payload, sample_groups, sample_batches=None, batch_offset=0: (
+                        sample_payloads[str(payload["scenario_label"])]
+                    ),
                 ),
             ):
                 payload = build_entity_alias_review_campaign(
@@ -216,7 +216,9 @@ class EntityAliasReviewCampaignTests(unittest.TestCase):
         self.assertEqual(payload["assistant_confidence_counts"], {"high": 1, "medium": 1})
         self.assertEqual(payload["bucket_counts"], {"likely-reject": 1, "needs-context": 1})
         self.assertIsNone(payload["proposal_reject_precision"])
-        self.assertEqual(payload["scenarios"][0]["proposal_payload"]["assistant_outcome_counts"], {"reject": 1})
+        self.assertEqual(
+            payload["scenarios"][0]["proposal_payload"]["assistant_outcome_counts"], {"reject": 1}
+        )
         self.assertEqual(
             payload["scenarios"][1]["proposal_payload"]["assistant_outcome_counts"],
             {"needs-context": 1},
@@ -270,7 +272,9 @@ class EntityAliasReviewCampaignTests(unittest.TestCase):
         self.assertIn("assistant: reject=2", text)
         self.assertIn("sample_artifact: /tmp/sample.md", text)
 
-    def test_write_entity_alias_review_campaign_artifacts_writes_manifest_and_scenarios(self) -> None:
+    def test_write_entity_alias_review_campaign_artifacts_writes_manifest_and_scenarios(
+        self,
+    ) -> None:
         scenario = {
             "label": "alpha",
             "description": "Alpha window",
@@ -302,7 +306,9 @@ class EntityAliasReviewCampaignTests(unittest.TestCase):
                 ),
                 patch(
                     "conversation_corpus_engine.triage.sample_entity_alias_review_assist_groups",
-                    side_effect=lambda payload, sample_groups, sample_batches=None, batch_offset=0: sample_payload,
+                    side_effect=lambda payload, sample_groups, sample_batches=None, batch_offset=0: (
+                        sample_payload
+                    ),
                 ),
             ):
                 payload = build_entity_alias_review_campaign(
@@ -329,7 +335,9 @@ class EntityAliasReviewCampaignTests(unittest.TestCase):
             self.assertTrue(Path(scenario_artifacts["sample"]["session_markdown_path"]).exists())
             self.assertTrue(Path(scenario_artifacts["summary"]["session_markdown_path"]).exists())
             self.assertTrue(Path(scenario_artifacts["proposal"]["session_markdown_path"]).exists())
-            self.assertTrue(Path(scenario_artifacts["comparison"]["session_markdown_path"]).exists())
+            self.assertTrue(
+                Path(scenario_artifacts["comparison"]["session_markdown_path"]).exists()
+            )
             latest_markdown = Path(artifacts["latest_markdown_path"]).read_text(encoding="utf-8")
             self.assertIn("Entity-alias review campaign", latest_markdown)
             self.assertIn("sample_artifact:", latest_markdown)
@@ -377,7 +385,7 @@ class EntityAliasReviewCampaignLedgerTests(unittest.TestCase):
                             "assistant_confidence": assistant_confidence,
                             "assistant_rationale": ["fixture rationale"],
                         }
-                    ]
+                    ],
                 }
             ),
             encoding="utf-8",
@@ -396,22 +404,36 @@ class EntityAliasReviewCampaignLedgerTests(unittest.TestCase):
                         "adjudicated_count": 1 if manual_outcome else 0,
                         "comparable_count": 1 if manual_outcome else 0,
                         "agreement_count": 1 if manual_outcome == assistant_outcome else 0,
-                        "disagreement_count": 0 if manual_outcome == assistant_outcome else (1 if manual_outcome else 0),
+                        "disagreement_count": 0
+                        if manual_outcome == assistant_outcome
+                        else (1 if manual_outcome else 0),
                         "proposal_reject_count": 1 if assistant_outcome == "reject" else 0,
                         "proposal_keep_count": 1 if assistant_outcome == "keep" else 0,
-                        "proposal_needs_context_count": 1 if assistant_outcome == "needs-context" else 0,
-                        "proposal_reject_hits": 1 if manual_outcome == "reject" and assistant_outcome == "reject" else 0,
-                        "proposal_reject_false_positives": 1 if manual_outcome == "keep" and assistant_outcome == "reject" else 0,
+                        "proposal_needs_context_count": 1
+                        if assistant_outcome == "needs-context"
+                        else 0,
+                        "proposal_reject_hits": 1
+                        if manual_outcome == "reject" and assistant_outcome == "reject"
+                        else 0,
+                        "proposal_reject_false_positives": 1
+                        if manual_outcome == "keep" and assistant_outcome == "reject"
+                        else 0,
                         "proposal_reject_precision": comparison_precision,
                         "confidence_summary": {
                             assistant_confidence: {
                                 "count": 1,
                                 "adjudicated_count": 1 if manual_outcome else 0,
                                 "agreement_count": 1 if manual_outcome == assistant_outcome else 0,
-                                "disagreement_count": 0 if manual_outcome == assistant_outcome else (1 if manual_outcome else 0),
+                                "disagreement_count": 0
+                                if manual_outcome == assistant_outcome
+                                else (1 if manual_outcome else 0),
                                 "proposal_reject_count": 1 if assistant_outcome == "reject" else 0,
-                                "proposal_reject_hits": 1 if manual_outcome == "reject" and assistant_outcome == "reject" else 0,
-                                "proposal_reject_false_positives": 1 if manual_outcome == "keep" and assistant_outcome == "reject" else 0,
+                                "proposal_reject_hits": 1
+                                if manual_outcome == "reject" and assistant_outcome == "reject"
+                                else 0,
+                                "proposal_reject_false_positives": 1
+                                if manual_outcome == "keep" and assistant_outcome == "reject"
+                                else 0,
                                 "reject_precision": comparison_precision,
                             }
                         },
@@ -446,7 +468,8 @@ class EntityAliasReviewCampaignLedgerTests(unittest.TestCase):
                                 "artifacts": {
                                     "sample": {
                                         "session_markdown_path": str(
-                                            reports_root / "review-assist-sample-2026-03-25-123012-122496-likely_front.md"
+                                            reports_root
+                                            / "review-assist-sample-2026-03-25-123012-122496-likely_front.md"
                                         )
                                     }
                                 },
@@ -498,7 +521,9 @@ class EntityAliasReviewCampaignLedgerTests(unittest.TestCase):
             self.assertEqual(payload["proposal_reject_false_positives"], 0)
             self.assertEqual(payload["proposal_reject_precision"], 1.0)
 
-    def test_build_entity_alias_review_campaign_index_matches_artifacts_by_source_paths(self) -> None:
+    def test_build_entity_alias_review_campaign_index_matches_artifacts_by_source_paths(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
             reports_root = project_root / "reports"
@@ -604,7 +629,10 @@ class EntityAliasReviewCampaignLedgerTests(unittest.TestCase):
             self.assertEqual(payload["current_adjudicated"], 0)
             self.assertEqual(payload["remaining_to_threshold"], 5)
             self.assertGreaterEqual(payload["candidate_packet_count"], 2)
-            self.assertIn(payload["packets"][0]["priority_bucket"], {"unlock-threshold-now", "precision-ready"})
+            self.assertIn(
+                payload["packets"][0]["priority_bucket"],
+                {"unlock-threshold-now", "precision-ready"},
+            )
 
     def test_build_entity_alias_review_apply_plan_stays_disabled_and_exposes_contract(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -710,14 +738,23 @@ class EntityAliasReviewCampaignLedgerTests(unittest.TestCase):
             "rollup": {"adjudicated_count": 1, "proposal_reject_precision": 1.0},
         }
 
-        self.assertIn("Entity-alias review campaign index", render_entity_alias_review_campaign_index(index_payload))
-        self.assertIn("Entity-alias review rollup", render_entity_alias_review_rollup(rollup_payload))
+        self.assertIn(
+            "Entity-alias review campaign index",
+            render_entity_alias_review_campaign_index(index_payload),
+        )
+        self.assertIn(
+            "Entity-alias review rollup", render_entity_alias_review_rollup(rollup_payload)
+        )
         self.assertIn("Entity-alias reject stage", render_entity_alias_reject_stage(stage_payload))
 
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
-            index_artifacts = write_entity_alias_review_campaign_index_artifacts(project_root, index_payload)
-            rollup_artifacts = write_entity_alias_review_rollup_artifacts(project_root, rollup_payload)
+            index_artifacts = write_entity_alias_review_campaign_index_artifacts(
+                project_root, index_payload
+            )
+            rollup_artifacts = write_entity_alias_review_rollup_artifacts(
+                project_root, rollup_payload
+            )
             stage_artifacts = write_entity_alias_reject_stage_artifacts(project_root, stage_payload)
 
             self.assertTrue(Path(index_artifacts["latest_markdown_path"]).exists())
@@ -736,7 +773,15 @@ class EntityAliasReviewCampaignLedgerTests(unittest.TestCase):
             "pending_count": 1,
             "warnings": [{"sample_index": 1, "type": "missing-bucket", "message": "fixture"}],
             "errors": [],
-            "samples": [{"sample_index": 1, "anchor": "chapters", "bucket": "likely-reject", "manual_outcome": "", "review_ids": ["review-1"]}],
+            "samples": [
+                {
+                    "sample_index": 1,
+                    "anchor": "chapters",
+                    "bucket": "likely-reject",
+                    "manual_outcome": "",
+                    "review_ids": ["review-1"],
+                }
+            ],
         }
         scoreboard_payload = {
             "project_root": "/tmp/project",
@@ -776,15 +821,30 @@ class EntityAliasReviewCampaignLedgerTests(unittest.TestCase):
             },
         }
 
-        self.assertIn("Entity-alias review packet hydration", render_entity_alias_review_packet_hydration(hydration_payload))
-        self.assertIn("Entity-alias review completion scoreboard", render_entity_alias_review_scoreboard(scoreboard_payload))
-        self.assertIn("Entity-alias review apply plan", render_entity_alias_review_apply_plan(apply_plan_payload))
+        self.assertIn(
+            "Entity-alias review packet hydration",
+            render_entity_alias_review_packet_hydration(hydration_payload),
+        )
+        self.assertIn(
+            "Entity-alias review completion scoreboard",
+            render_entity_alias_review_scoreboard(scoreboard_payload),
+        )
+        self.assertIn(
+            "Entity-alias review apply plan",
+            render_entity_alias_review_apply_plan(apply_plan_payload),
+        )
 
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
-            hydration_artifacts = write_entity_alias_review_packet_hydration_artifacts(project_root, hydration_payload)
-            scoreboard_artifacts = write_entity_alias_review_scoreboard_artifacts(project_root, scoreboard_payload)
-            apply_plan_artifacts = write_entity_alias_review_apply_plan_artifacts(project_root, apply_plan_payload)
+            hydration_artifacts = write_entity_alias_review_packet_hydration_artifacts(
+                project_root, hydration_payload
+            )
+            scoreboard_artifacts = write_entity_alias_review_scoreboard_artifacts(
+                project_root, scoreboard_payload
+            )
+            apply_plan_artifacts = write_entity_alias_review_apply_plan_artifacts(
+                project_root, apply_plan_payload
+            )
 
             self.assertTrue(Path(hydration_artifacts["latest_markdown_path"]).exists())
             self.assertTrue(Path(scoreboard_artifacts["latest_markdown_path"]).exists())
@@ -1153,7 +1213,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
             self.assertEqual(payload["relation_counts"]["partial-overlap"], 1)
             self.assertEqual(payload["batches"][0]["anchors"], ["apps"])
 
-    def test_build_entity_alias_review_assist_applies_relation_source_and_anchor_filters(self) -> None:
+    def test_build_entity_alias_review_assist_applies_relation_source_and_anchor_filters(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
             state_dir = project_root / "state"
@@ -1185,7 +1247,10 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                         "review_type": "entity-alias",
                         "status": "open",
                         "title": "Data Pipeline <> Pipeline Orchestration",
-                        "subject_ids": ["c:entity-data-pipeline", "d:entity-pipeline-orchestration"],
+                        "subject_ids": [
+                            "c:entity-data-pipeline",
+                            "d:entity-pipeline-orchestration",
+                        ],
                         "suggested_canonical_subject": "data-pipeline",
                         "score": 0.74,
                         "source_corpora": ["c", "d"],
@@ -1269,7 +1334,10 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
         self.assertIn("bucket: mixed-review", text)
         self.assertIn("flags: has-low-specificity-labels", text)
         self.assertIn("example: Apps <> Websites [disjoint]", text)
-        self.assertIn("review: Verify labels are not headings, placeholders, fragments, or extraction residue.", text)
+        self.assertIn(
+            "review: Verify labels are not headings, placeholders, fragments, or extraction residue.",
+            text,
+        )
 
     def test_select_entity_alias_review_assist_batch_reduces_payload_to_single_batch(self) -> None:
         payload = {
@@ -1288,24 +1356,26 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                     "anchor": "apps",
                     "item_count": 2,
                     "max_score": 1.0,
-                        "relation_counts": {"disjoint": 2},
-                        "source_pair_counts": {"a <> b": 2},
-                        "labels": ["Apps", "Websites"],
-                        "review_bucket": "needs-context",
-                        "signal_flags": ["has-high-score-disjoint-pairs", "all-zero-overlap"],
-                        "signal_counts": {
-                            "disjoint_count": 2,
-                            "zero_overlap_count": 2,
-                            "high_score_count": 2,
-                            "low_specificity_entry_count": 0,
-                        },
-                        "checklist": ["Inspect the highest-scoring pair before rejecting; upstream signal is stronger than lexical overlap."],
-                        "example_review_ids": ["review-1", "review-2"],
-                        "items": [
-                            {
-                                "review_id": "review-1",
-                                "title": "Apps <> Websites",
-                                "relation": "disjoint",
+                    "relation_counts": {"disjoint": 2},
+                    "source_pair_counts": {"a <> b": 2},
+                    "labels": ["Apps", "Websites"],
+                    "review_bucket": "needs-context",
+                    "signal_flags": ["has-high-score-disjoint-pairs", "all-zero-overlap"],
+                    "signal_counts": {
+                        "disjoint_count": 2,
+                        "zero_overlap_count": 2,
+                        "high_score_count": 2,
+                        "low_specificity_entry_count": 0,
+                    },
+                    "checklist": [
+                        "Inspect the highest-scoring pair before rejecting; upstream signal is stronger than lexical overlap."
+                    ],
+                    "example_review_ids": ["review-1", "review-2"],
+                    "items": [
+                        {
+                            "review_id": "review-1",
+                            "title": "Apps <> Websites",
+                            "relation": "disjoint",
                             "score": 1.0,
                             "priority": "high",
                             "source_pair": "a <> b",
@@ -1324,24 +1394,26 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                     "anchor": "data pipeline",
                     "item_count": 1,
                     "max_score": 0.7,
-                        "relation_counts": {"disjoint": 1},
-                        "source_pair_counts": {"a <> b": 1},
-                        "labels": ["Data Pipeline", "Workflow"],
-                        "review_bucket": "likely-reject",
-                        "signal_flags": ["all-zero-overlap"],
-                        "signal_counts": {
-                            "disjoint_count": 1,
-                            "zero_overlap_count": 1,
-                            "high_score_count": 0,
-                            "low_specificity_entry_count": 0,
-                        },
-                        "checklist": ["Reject unless external context ties these labels to the same entity."],
-                        "example_review_ids": ["review-3"],
-                        "items": [
-                            {
-                                "review_id": "review-3",
-                                "title": "Data Pipeline <> Workflow",
-                                "relation": "disjoint",
+                    "relation_counts": {"disjoint": 1},
+                    "source_pair_counts": {"a <> b": 1},
+                    "labels": ["Data Pipeline", "Workflow"],
+                    "review_bucket": "likely-reject",
+                    "signal_flags": ["all-zero-overlap"],
+                    "signal_counts": {
+                        "disjoint_count": 1,
+                        "zero_overlap_count": 1,
+                        "high_score_count": 0,
+                        "low_specificity_entry_count": 0,
+                    },
+                    "checklist": [
+                        "Reject unless external context ties these labels to the same entity."
+                    ],
+                    "example_review_ids": ["review-3"],
+                    "items": [
+                        {
+                            "review_id": "review-3",
+                            "title": "Data Pipeline <> Workflow",
+                            "relation": "disjoint",
                             "score": 0.7,
                             "priority": "high",
                             "source_pair": "a <> b",
@@ -1352,24 +1424,26 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                     "anchor": "care",
                     "item_count": 1,
                     "max_score": 0.6,
-                        "relation_counts": {"disjoint": 1},
-                        "source_pair_counts": {"a <> b": 1},
-                        "labels": ["Care", "Dog"],
-                        "review_bucket": "likely-reject",
-                        "signal_flags": ["all-zero-overlap"],
-                        "signal_counts": {
-                            "disjoint_count": 1,
-                            "zero_overlap_count": 1,
-                            "high_score_count": 0,
-                            "low_specificity_entry_count": 0,
-                        },
-                        "checklist": ["Reject unless external context ties these labels to the same entity."],
-                        "example_review_ids": ["review-4"],
-                        "items": [
-                            {
-                                "review_id": "review-4",
-                                "title": "Care <> Dog",
-                                "relation": "disjoint",
+                    "relation_counts": {"disjoint": 1},
+                    "source_pair_counts": {"a <> b": 1},
+                    "labels": ["Care", "Dog"],
+                    "review_bucket": "likely-reject",
+                    "signal_flags": ["all-zero-overlap"],
+                    "signal_counts": {
+                        "disjoint_count": 1,
+                        "zero_overlap_count": 1,
+                        "high_score_count": 0,
+                        "low_specificity_entry_count": 0,
+                    },
+                    "checklist": [
+                        "Reject unless external context ties these labels to the same entity."
+                    ],
+                    "example_review_ids": ["review-4"],
+                    "items": [
+                        {
+                            "review_id": "review-4",
+                            "title": "Care <> Dog",
+                            "relation": "disjoint",
                             "score": 0.6,
                             "priority": "medium",
                             "source_pair": "a <> b",
@@ -1441,7 +1515,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                     "review_bucket": "needs-context",
                     "signal_flags": ["has-high-score-disjoint-pairs"],
                     "signal_counts": {"disjoint_count": 2},
-                    "checklist": ["Inspect the highest-scoring pair before rejecting; upstream signal is stronger than lexical overlap."],
+                    "checklist": [
+                        "Inspect the highest-scoring pair before rejecting; upstream signal is stronger than lexical overlap."
+                    ],
                     "example_review_ids": ["review-1"],
                     "items": [
                         {
@@ -1472,7 +1548,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                     "review_bucket": "likely-reject",
                     "signal_flags": ["all-zero-overlap"],
                     "signal_counts": {"disjoint_count": 2},
-                    "checklist": ["Reject unless external context ties these labels to the same entity."],
+                    "checklist": [
+                        "Reject unless external context ties these labels to the same entity."
+                    ],
                     "example_review_ids": ["review-3"],
                     "items": [
                         {
@@ -1503,7 +1581,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                     "review_bucket": "likely-reject",
                     "signal_flags": ["all-zero-overlap", "has-low-specificity-labels"],
                     "signal_counts": {"disjoint_count": 2},
-                    "checklist": ["Reject unless external context ties these labels to the same entity."],
+                    "checklist": [
+                        "Reject unless external context ties these labels to the same entity."
+                    ],
                     "example_review_ids": ["review-5"],
                     "items": [
                         {
@@ -1585,7 +1665,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                             "review_bucket": "likely-reject",
                             "signal_flags": ["all-zero-overlap"],
                             "signal_counts": {"disjoint_count": 2},
-                            "checklist": ["Reject unless external context ties these labels to the same entity."],
+                            "checklist": [
+                                "Reject unless external context ties these labels to the same entity."
+                            ],
                             "example_review_ids": ["review-1"],
                             "items": [
                                 {
@@ -1608,7 +1690,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                             "review_bucket": "likely-reject",
                             "signal_flags": ["all-zero-overlap"],
                             "signal_counts": {"disjoint_count": 2},
-                            "checklist": ["Reject unless external context ties these labels to the same entity."],
+                            "checklist": [
+                                "Reject unless external context ties these labels to the same entity."
+                            ],
                             "example_review_ids": ["review-2"],
                             "items": [
                                 {
@@ -1639,7 +1723,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                             "review_bucket": "likely-reject",
                             "signal_flags": ["all-zero-overlap", "has-low-specificity-labels"],
                             "signal_counts": {"disjoint_count": 2},
-                            "checklist": ["Reject unless external context ties these labels to the same entity."],
+                            "checklist": [
+                                "Reject unless external context ties these labels to the same entity."
+                            ],
                             "example_review_ids": ["review-3"],
                             "items": [
                                 {
@@ -1662,7 +1748,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                             "review_bucket": "likely-reject",
                             "signal_flags": ["all-zero-overlap", "has-low-specificity-labels"],
                             "signal_counts": {"disjoint_count": 2},
-                            "checklist": ["Reject unless external context ties these labels to the same entity."],
+                            "checklist": [
+                                "Reject unless external context ties these labels to the same entity."
+                            ],
                             "example_review_ids": ["review-4"],
                             "items": [
                                 {
@@ -1691,7 +1779,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
         self.assertEqual(sampled["sample"]["selected_group_count"], 3)
         self.assertEqual(sampled["sample"]["candidate_group_count"], 4)
         self.assertEqual(sampled["sample"]["candidate_batch_count"], 2)
-        self.assertEqual([group["anchor"] for group in sampled["groups"]], ["care", "chapters", "extension"])
+        self.assertEqual(
+            [group["anchor"] for group in sampled["groups"]], ["care", "chapters", "extension"]
+        )
         self.assertEqual(sampled["batches"][0]["anchors"], ["care", "extension"])
         self.assertEqual(sampled["batches"][1]["anchors"], ["chapters"])
 
@@ -1722,9 +1812,20 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                             "review_bucket": "likely-reject",
                             "signal_flags": ["all-zero-overlap"],
                             "signal_counts": {"disjoint_count": 1},
-                            "checklist": ["Reject unless external context ties these labels to the same entity."],
+                            "checklist": [
+                                "Reject unless external context ties these labels to the same entity."
+                            ],
                             "example_review_ids": ["review-a"],
-                            "items": [{"review_id": "review-a", "title": "A <> Z", "relation": "disjoint", "score": 0.9, "priority": "medium", "source_pair": "x <> y"}],
+                            "items": [
+                                {
+                                    "review_id": "review-a",
+                                    "title": "A <> Z",
+                                    "relation": "disjoint",
+                                    "score": 0.9,
+                                    "priority": "medium",
+                                    "source_pair": "x <> y",
+                                }
+                            ],
                         },
                         {
                             "anchor": "b",
@@ -1736,9 +1837,20 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                             "review_bucket": "likely-reject",
                             "signal_flags": ["all-zero-overlap"],
                             "signal_counts": {"disjoint_count": 1},
-                            "checklist": ["Reject unless external context ties these labels to the same entity."],
+                            "checklist": [
+                                "Reject unless external context ties these labels to the same entity."
+                            ],
                             "example_review_ids": ["review-b"],
-                            "items": [{"review_id": "review-b", "title": "B <> Z", "relation": "disjoint", "score": 0.8, "priority": "medium", "source_pair": "x <> y"}],
+                            "items": [
+                                {
+                                    "review_id": "review-b",
+                                    "title": "B <> Z",
+                                    "relation": "disjoint",
+                                    "score": 0.8,
+                                    "priority": "medium",
+                                    "source_pair": "x <> y",
+                                }
+                            ],
                         },
                     ],
                 },
@@ -1758,9 +1870,20 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                             "review_bucket": "likely-reject",
                             "signal_flags": ["all-zero-overlap"],
                             "signal_counts": {"disjoint_count": 1},
-                            "checklist": ["Reject unless external context ties these labels to the same entity."],
+                            "checklist": [
+                                "Reject unless external context ties these labels to the same entity."
+                            ],
                             "example_review_ids": ["review-c"],
-                            "items": [{"review_id": "review-c", "title": "C <> Z", "relation": "disjoint", "score": 0.7, "priority": "medium", "source_pair": "x <> y"}],
+                            "items": [
+                                {
+                                    "review_id": "review-c",
+                                    "title": "C <> Z",
+                                    "relation": "disjoint",
+                                    "score": 0.7,
+                                    "priority": "medium",
+                                    "source_pair": "x <> y",
+                                }
+                            ],
                         },
                         {
                             "anchor": "d",
@@ -1772,9 +1895,20 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                             "review_bucket": "likely-reject",
                             "signal_flags": ["all-zero-overlap"],
                             "signal_counts": {"disjoint_count": 1},
-                            "checklist": ["Reject unless external context ties these labels to the same entity."],
+                            "checklist": [
+                                "Reject unless external context ties these labels to the same entity."
+                            ],
                             "example_review_ids": ["review-d"],
-                            "items": [{"review_id": "review-d", "title": "D <> Z", "relation": "disjoint", "score": 0.6, "priority": "medium", "source_pair": "x <> y"}],
+                            "items": [
+                                {
+                                    "review_id": "review-d",
+                                    "title": "D <> Z",
+                                    "relation": "disjoint",
+                                    "score": 0.6,
+                                    "priority": "medium",
+                                    "source_pair": "x <> y",
+                                }
+                            ],
                         },
                     ],
                 },
@@ -1794,9 +1928,20 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                             "review_bucket": "likely-reject",
                             "signal_flags": ["all-zero-overlap"],
                             "signal_counts": {"disjoint_count": 1},
-                            "checklist": ["Reject unless external context ties these labels to the same entity."],
+                            "checklist": [
+                                "Reject unless external context ties these labels to the same entity."
+                            ],
                             "example_review_ids": ["review-e"],
-                            "items": [{"review_id": "review-e", "title": "E <> Z", "relation": "disjoint", "score": 0.5, "priority": "medium", "source_pair": "x <> y"}],
+                            "items": [
+                                {
+                                    "review_id": "review-e",
+                                    "title": "E <> Z",
+                                    "relation": "disjoint",
+                                    "score": 0.5,
+                                    "priority": "medium",
+                                    "source_pair": "x <> y",
+                                }
+                            ],
                         },
                         {
                             "anchor": "f",
@@ -1808,9 +1953,20 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                             "review_bucket": "likely-reject",
                             "signal_flags": ["all-zero-overlap"],
                             "signal_counts": {"disjoint_count": 1},
-                            "checklist": ["Reject unless external context ties these labels to the same entity."],
+                            "checklist": [
+                                "Reject unless external context ties these labels to the same entity."
+                            ],
                             "example_review_ids": ["review-f"],
-                            "items": [{"review_id": "review-f", "title": "F <> Z", "relation": "disjoint", "score": 0.4, "priority": "medium", "source_pair": "x <> y"}],
+                            "items": [
+                                {
+                                    "review_id": "review-f",
+                                    "title": "F <> Z",
+                                    "relation": "disjoint",
+                                    "score": 0.4,
+                                    "priority": "medium",
+                                    "source_pair": "x <> y",
+                                }
+                            ],
                         },
                     ],
                 },
@@ -1873,7 +2029,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
 
             artifacts = write_entity_alias_review_assist_artifacts(project_root, payload)
 
-            stored_payload = json.loads(Path(artifacts["latest_json_path"]).read_text(encoding="utf-8"))
+            stored_payload = json.loads(
+                Path(artifacts["latest_json_path"]).read_text(encoding="utf-8")
+            )
             latest_markdown = Path(artifacts["latest_markdown_path"]).read_text(encoding="utf-8")
             dated_markdown = Path(artifacts["report_path"]).read_text(encoding="utf-8")
 
@@ -1916,7 +2074,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                             "high_score_count": 2,
                             "low_specificity_entry_count": 0,
                         },
-                        "checklist": ["Inspect the highest-scoring pair before rejecting; upstream signal is stronger than lexical overlap."],
+                        "checklist": [
+                            "Inspect the highest-scoring pair before rejecting; upstream signal is stronger than lexical overlap."
+                        ],
                         "example_review_ids": ["review-1"],
                         "items": [
                             {
@@ -1959,7 +2119,10 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
             self.assertIn("from 4 filtered / 6 open", markdown)
             self.assertIn("# Entity-alias review checklist: entity-alias-batch-001", checklist)
             self.assertIn("- Bucket: needs-context", checklist)
-            self.assertIn("- Review: Inspect the highest-scoring pair before rejecting; upstream signal is stronger than lexical overlap.", checklist)
+            self.assertIn(
+                "- Review: Inspect the highest-scoring pair before rejecting; upstream signal is stronger than lexical overlap.",
+                checklist,
+            )
 
     def test_render_entity_alias_review_checklist_formats_group_guidance(self) -> None:
         text = render_entity_alias_review_checklist(
@@ -2028,7 +2191,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                                 "score": 0.83,
                             }
                         ],
-                        "checklist": ["Reject unless external context ties these labels to the same entity."],
+                        "checklist": [
+                            "Reject unless external context ties these labels to the same entity."
+                        ],
                     },
                     {
                         "anchor": "von",
@@ -2043,7 +2208,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                                 "score": 0.71,
                             }
                         ],
-                        "checklist": ["Reject unless external context ties these labels to the same entity."],
+                        "checklist": [
+                            "Reject unless external context ties these labels to the same entity."
+                        ],
                     },
                 ],
             }
@@ -2055,7 +2222,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
         self.assertIn("## Sample 1: chapters", text)
         self.assertIn("- Proposed outcome: reject", text)
 
-    def test_write_entity_alias_review_sample_artifacts_writes_latest_and_session_files(self) -> None:
+    def test_write_entity_alias_review_sample_artifacts_writes_latest_and_session_files(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
             payload = {
@@ -2083,7 +2252,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                                 "score": 0.83,
                             }
                         ],
-                        "checklist": ["Reject unless external context ties these labels to the same entity."],
+                        "checklist": [
+                            "Reject unless external context ties these labels to the same entity."
+                        ],
                     }
                 ],
                 "batches": [],
@@ -2230,7 +2401,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
         self.assertIn("- chapters  bucket=likely-reject  proposed=reject  manual=reject", text)
         self.assertIn("notes: clear heading residue", text)
 
-    def test_write_entity_alias_review_sample_summary_artifacts_writes_latest_and_session_files(self) -> None:
+    def test_write_entity_alias_review_sample_summary_artifacts_writes_latest_and_session_files(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
             payload = {
@@ -2349,7 +2522,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
         self.assertIn("rationale: Lexical overlap is absent across the sampled pairs.", text)
         self.assertIn("manual: keep", text)
 
-    def test_write_entity_alias_review_sample_proposal_artifacts_writes_latest_and_session_files(self) -> None:
+    def test_write_entity_alias_review_sample_proposal_artifacts_writes_latest_and_session_files(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
             payload = {
@@ -2385,7 +2560,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
             self.assertIn("Entity-alias review sample proposal", markdown)
             self.assertIn("assistant=reject", markdown)
 
-    def test_compare_entity_alias_review_sample_to_proposal_computes_agreement_metrics(self) -> None:
+    def test_compare_entity_alias_review_sample_to_proposal_computes_agreement_metrics(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
             sample_path = tmp / "sample.md"
@@ -2426,21 +2603,27 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                                 "review_ids": ["review-1", "review-2"],
                                 "assistant_outcome": "reject",
                                 "assistant_confidence": "high",
-                                "assistant_rationale": ["Group is already classified as likely-reject."],
+                                "assistant_rationale": [
+                                    "Group is already classified as likely-reject."
+                                ],
                             },
                             {
                                 "anchor": "extension",
                                 "review_ids": ["review-3"],
                                 "assistant_outcome": "reject",
                                 "assistant_confidence": "high",
-                                "assistant_rationale": ["Lexical overlap is absent across the sampled pairs."],
+                                "assistant_rationale": [
+                                    "Lexical overlap is absent across the sampled pairs."
+                                ],
                             },
                             {
                                 "anchor": "alias",
                                 "review_ids": ["review-4"],
                                 "assistant_outcome": "keep",
                                 "assistant_confidence": "medium",
-                                "assistant_rationale": ["Lexical overlap is strong enough that rejection is not the safe default."],
+                                "assistant_rationale": [
+                                    "Lexical overlap is strong enough that rejection is not the safe default."
+                                ],
                             },
                         ]
                     }
@@ -2463,7 +2646,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
             self.assertEqual(comparison["confidence_summary"]["high"]["reject_precision"], 0.5)
             self.assertEqual(comparison["disagreements"][0]["anchor"], "extension")
 
-    def test_compare_entity_alias_review_sample_to_proposal_leaves_precision_null_without_adjudication(self) -> None:
+    def test_compare_entity_alias_review_sample_to_proposal_leaves_precision_null_without_adjudication(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
             sample_path = tmp / "sample.md"
@@ -2491,7 +2676,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                                 "review_ids": ["review-1"],
                                 "assistant_outcome": "reject",
                                 "assistant_confidence": "high",
-                                "assistant_rationale": ["Group is already classified as likely-reject."],
+                                "assistant_rationale": [
+                                    "Group is already classified as likely-reject."
+                                ],
                             }
                         ]
                     }
@@ -2529,7 +2716,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
                         "assistant_outcome": "reject",
                         "assistant_confidence": "high",
                         "notes": "context overruled lexical mismatch",
-                        "assistant_rationale": ["Lexical overlap is absent across the sampled pairs."],
+                        "assistant_rationale": [
+                            "Lexical overlap is absent across the sampled pairs."
+                        ],
                     }
                 ],
             }
@@ -2541,7 +2730,9 @@ class EntityAliasReviewAssistTests(unittest.TestCase):
         self.assertIn("- extension  manual=keep  assistant=reject  confidence=high", text)
         self.assertIn("notes: context overruled lexical mismatch", text)
 
-    def test_write_entity_alias_review_sample_comparison_artifacts_writes_latest_and_session_files(self) -> None:
+    def test_write_entity_alias_review_sample_comparison_artifacts_writes_latest_and_session_files(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
             payload = {

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -9,8 +8,8 @@ from unittest.mock import patch
 
 from conversation_corpus_engine.triage import (
     _strip_uuid_suffix,
-    build_entity_alias_review_apply_plan,
     build_entity_alias_reject_stage,
+    build_entity_alias_review_apply_plan,
     build_entity_alias_review_assist,
     build_entity_alias_review_campaign,
     build_entity_alias_review_campaign_index,
@@ -24,35 +23,35 @@ from conversation_corpus_engine.triage import (
     hydrate_entity_alias_review_sample_packet,
     parse_entity_alias_review_sample_markdown,
     propose_entity_alias_review_sample,
-    render_entity_alias_review_apply_plan,
     render_entity_alias_reject_stage,
-    report_stamp,
+    render_entity_alias_review_apply_plan,
+    render_entity_alias_review_assist,
     render_entity_alias_review_campaign,
     render_entity_alias_review_campaign_index,
-    render_entity_alias_review_rollup,
-    render_entity_alias_review_scoreboard,
-    render_entity_alias_review_packet_hydration,
     render_entity_alias_review_checklist,
+    render_entity_alias_review_packet_hydration,
+    render_entity_alias_review_rollup,
+    render_entity_alias_review_sample,
     render_entity_alias_review_sample_comparison,
     render_entity_alias_review_sample_proposal,
-    render_entity_alias_review_sample,
     render_entity_alias_review_sample_summary,
-    render_entity_alias_review_assist,
+    render_entity_alias_review_scoreboard,
+    report_stamp,
     sample_entity_alias_review_assist_groups,
     select_entity_alias_review_assist_batch,
     summarize_entity_alias_review_sample,
+    write_entity_alias_reject_stage_artifacts,
+    write_entity_alias_review_apply_plan_artifacts,
     write_entity_alias_review_assist_artifacts,
     write_entity_alias_review_campaign_artifacts,
     write_entity_alias_review_campaign_index_artifacts,
-    write_entity_alias_review_rollup_artifacts,
-    write_entity_alias_reject_stage_artifacts,
-    write_entity_alias_review_apply_plan_artifacts,
     write_entity_alias_review_packet_hydration_artifacts,
-    write_entity_alias_review_scoreboard_artifacts,
+    write_entity_alias_review_rollup_artifacts,
     write_entity_alias_review_sample_artifacts,
     write_entity_alias_review_sample_comparison_artifacts,
     write_entity_alias_review_sample_proposal_artifacts,
     write_entity_alias_review_sample_summary_artifacts,
+    write_entity_alias_review_scoreboard_artifacts,
 )
 
 

--- a/tests/test_workspace_inventory.py
+++ b/tests/test_workspace_inventory.py
@@ -20,7 +20,9 @@ def _write_engagement(path: Path, engagement_id: str) -> None:
 def test_commerce_inventory_finds_eng_001_through_eng_005(tmp_path: Path, monkeypatch) -> None:
     workspace_root = tmp_path / "Workspace"
     commerce_root = workspace_root / "organvm" / "commerce--meta"
-    _write_engagement(commerce_root / "engagements" / "active" / "sovereign-systems.yaml", "ENG-001")
+    _write_engagement(
+        commerce_root / "engagements" / "active" / "sovereign-systems.yaml", "ENG-001"
+    )
     _write_engagement(
         commerce_root / "engagements" / "active" / "public-record-data-scrapper.yaml",
         "ENG-002",
@@ -47,6 +49,9 @@ def test_commerce_inventory_finds_eng_001_through_eng_005(tmp_path: Path, monkey
     assert set(records) == {"ENG-001", "ENG-002", "ENG-003", "ENG-004", "ENG-005"}
     assert records["ENG-001"].name == "sovereign-systems.yaml"
     assert records["ENG-004"].name == "post-proto-mousike-nomos.yaml"
-    assert find_commerce_engagement_record("ENG-005") == (
-        commerce_root / "engagements" / "active" / "content-engine-asset-amplifier.yaml"
-    ).resolve()
+    assert (
+        find_commerce_engagement_record("ENG-005")
+        == (
+            commerce_root / "engagements" / "active" / "content-engine-asset-amplifier.yaml"
+        ).resolve()
+    )


### PR DESCRIPTION
Resolves LIMEN-057. Tuned Layer 4 orchestration to address CPU throttling.

## Summary by Sourcery

Add a Codex session converter utility and tighten local-session/CI plumbing while applying style-focused refactors across triage, CLI, and tests.

New Features:
- Introduce a codex_to_bundle script to convert Codex CLI JSONL session exports into a ChatGPT-style conversations bundle consumable by the existing import adapter.
- Add persona extract artifact writing into a generated storefront docs location to surface persona analysis outputs.

Enhancements:
- Refine entity-alias triage orchestration, review-assist utilities, and campaign rollup helpers for clearer control flow, diagnostics, and path handling without changing external behavior.
- Polish CLI and import helpers for ChatGPT and Claude local sessions, improving argument wiring and summary metadata while preserving existing command surfaces.

Build:
- Pin GitHub Actions checkout and setup-python to specific SHAs in CI workflows for reproducible builds.

CI:
- Keep schema-check and test workflows aligned with pinned GitHub Actions versions.

Deployment:
- Reduce the per-provider timeout in the local session refresh script to shorten or prevent long-running refresh jobs.

Tests:
- Update and expand tests around triage workflows, CLI review-assist flows, provider catalog, workspace inventory, source lifecycle, and local-session import paths to reflect the refactors and new utilities.