### PR TITLE
feat: Claude Code session JSONL pre-converter (#36)

### DIFF
--- a/scripts/claude_code_to_bundle.py
+++ b/scripts/claude_code_to_bundle.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""claude_code_to_bundle — Convert Claude Code session JSONL transcripts into a
+standard ChatGPT-export bundle that the engine's `import_chatgpt_export_corpus`
+adapter can ingest.
+
+Background
+----------
+Claude Code stores session transcripts as plain-text JSONL files under
+`~/.claude/projects/<scope-slug>/<session-uuid>.jsonl`, one JSON event per
+line. The lines relevant to conversation history have `type == "user"` or
+`type == "assistant"` and carry a `sessionId` UUID, an ISO-8601 `timestamp`,
+an event `uuid`, and a `message` object:
+
+    {"type": "user"|"assistant",
+     "sessionId": "<uuid>", "timestamp": "<iso8601>", "uuid": "...",
+     "isSidechain": false,
+     "message": {"role": "user"|"assistant", "content": str | [blocks]}}
+
+Content blocks (in `message.content` lists) are tagged:
+
+    {"type": "text", "text": ...}                       -> message text (kept)
+    {"type": "thinking", "thinking": ...}               -> reasoning (skipped)
+    {"type": "tool_use", "name": ..., "input": {...}}   -> tool call (skipped)
+    {"type": "tool_result", "content": ...}             -> tool output (skipped)
+
+Sidechain events (`isSidechain == true`) are subagent traffic — their "user"
+turns are synthetic orchestrator prompts, not the human — and are skipped by
+default (`--include-sidechains` keeps them). Other event types (`system`,
+`summary`, `mode`, `file-history-snapshot`, ...) carry no conversation turns.
+
+User prompt text passes through byte-identical: no trimming, no whitespace
+normalization. Emptiness checks are performed on a stripped copy only.
+
+The engine's official adapter expects the standard ChatGPT-export bundle:
+
+    bundle/
+      conversations.json    # list of conversations with mapping/parent/children
+      user.json
+
+This script reads one or more `*.jsonl` transcripts, filters conversation
+events, groups them by session UUID, and emits a synthetic bundle dir.
+
+Usage
+-----
+    python scripts/claude_code_to_bundle.py <input-dir> [<input-dir> ...] <output-bundle-dir>
+
+Then ingest with the standard adapter:
+    cce provider import --provider chatgpt --source-drop-root <drop-root> --register --build
+(with the bundle placed at `<drop-root>/chatgpt/inbox/<bundle-dir>`), or
+directly:
+    cce provider import --provider chatgpt --source-path <output-bundle-dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+def _session_id_from_path(path: Path) -> str:
+    """Derive a stable session ID from a file path stem."""
+    raw = path.stem
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:36]
+
+
+def _ensure_timestamp(ts: Any) -> float:
+    """Convert a timestamp value (epoch number or ISO-8601 string) to epoch seconds."""
+    if ts is None:
+        return 0.0
+    if isinstance(ts, (int, float)):
+        return float(ts)
+    if isinstance(ts, str):
+        raw = ts.strip()
+        if raw.endswith(("Z", "z")):
+            raw = raw[:-1] + "+00:00"
+        try:
+            return datetime.fromisoformat(raw).timestamp()
+        except (ValueError, TypeError):
+            return 0.0
+    return 0.0
+
+
+def _normalize_role(role: str | None) -> str:
+    if not role:
+        return "user"
+    r = role.strip().lower()
+    if r in ("user", "human", "you"):
+        return "user"
+    if r in ("assistant", "ai", "bot", "model", "claude"):
+        return "assistant"
+    return "user"
+
+
+def _extract_parts(content: Any) -> list[str]:
+    """Extract verbatim text parts from a Claude Code `message.content` value.
+
+    String content is the typical user prompt — returned untouched (the prompt
+    is the sacred object; byte-identical pass-through). List content is walked
+    block by block: `text` blocks are kept verbatim; `thinking`, `tool_use`,
+    `tool_result`, and image blocks are skipped (no conversational text).
+    """
+    if isinstance(content, str):
+        return [content] if content.strip() else []
+    if not isinstance(content, list):
+        return []
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, str):
+            if block.strip():
+                parts.append(block)
+            continue
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "text":
+            text = block.get("text")
+            if isinstance(text, str) and text.strip():
+                parts.append(text)
+    return parts
+
+
+def discover_input_files(input_paths: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for p in input_paths:
+        if p.is_dir():
+            files.extend(sorted(p.glob("*.jsonl")))
+        elif p.suffix == ".jsonl" and p.exists():
+            files.append(p)
+        else:
+            print(f"  skip (not found/not JSONL): {p}", file=sys.stderr)
+    return files
+
+
+def convert_directory(
+    input_paths: list[Path],
+    output_bundle: Path,
+    *,
+    include_sidechains: bool = False,
+) -> dict:
+    """Read Claude Code session JSONL files, write a standard bundle to output_bundle."""
+    files = discover_input_files(input_paths)
+    if not files:
+        raise FileNotFoundError(f"no *.jsonl files found under any of: {input_paths}")
+
+    # Group conversation events by session UUID
+    sessions: dict[str, list[dict]] = {}
+    seen_items: set[str] = set()  # dedup by event uuid (fallback: content hash)
+    skipped_invalid = 0
+    skipped_sidechain = 0
+    lines_total = 0
+
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            print(f"  skip (unreadable): {path.name} — {exc}", file=sys.stderr)
+            continue
+
+        last_ts = 0.0
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            lines_total += 1
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                skipped_invalid += 1
+                continue
+            if not isinstance(record, dict):
+                skipped_invalid += 1
+                continue
+
+            if record.get("type") not in ("user", "assistant"):
+                continue
+            message = record.get("message")
+            if not isinstance(message, dict):
+                continue
+            if record.get("isSidechain") and not include_sidechains:
+                skipped_sidechain += 1
+                continue
+
+            role = _normalize_role(message.get("role") or record.get("type"))
+            parts = _extract_parts(message.get("content"))
+            if not parts:
+                continue
+
+            session_id = record.get("sessionId") or _session_id_from_path(path)
+
+            # Dedup by native event uuid within same session (resumed sessions
+            # replay earlier events); fall back to a content hash.
+            event_uid = record.get("uuid")
+            if not event_uid:
+                joined = "\n".join(parts)
+                event_uid = hashlib.md5(joined.encode("utf-8")).hexdigest()
+            dedup_key = f"{session_id}:{event_uid}"
+            if dedup_key in seen_items:
+                continue
+            seen_items.add(dedup_key)
+
+            ts = _ensure_timestamp(record.get("timestamp"))
+            if ts <= 0.0:
+                ts = last_ts  # preserve file order for unstamped events
+            else:
+                last_ts = ts
+
+            sessions.setdefault(session_id, []).append(
+                {
+                    "role": role,
+                    "parts": parts,
+                    "timestamp": ts,
+                    "session": session_id,
+                }
+            )
+
+    if not sessions:
+        raise ValueError("no valid conversation events found in any input file")
+
+    # Build conversations in bundle format
+    conversations: list[dict] = []
+    skipped_empty_session = 0
+    messages_written = 0
+
+    for session_id, items in sessions.items():
+        # Stable sort: equal/carried timestamps keep original file order.
+        items.sort(key=lambda x: x["timestamp"])
+        if not items:
+            skipped_empty_session += 1
+            continue
+
+        create_time = items[0]["timestamp"]
+        update_time = items[-1]["timestamp"]
+
+        mapping: dict[str, dict[str, Any]] = {}
+        root_id = f"claude-code-root-{session_id}"
+        mapping[root_id] = {
+            "id": root_id,
+            "parent": None,
+            "children": [],
+            "message": None,
+        }
+
+        prev_id = root_id
+        for i, msg in enumerate(items, start=1):
+            node_id = f"claude-code-msg-{session_id}-{i:04d}"
+            mapping[node_id] = {
+                "id": node_id,
+                "parent": prev_id,
+                "children": [],
+                "message": {
+                    "id": node_id,
+                    "author": {"role": msg["role"]},
+                    "create_time": msg["timestamp"],
+                    "content": {"content_type": "text", "parts": msg["parts"]},
+                },
+            }
+            mapping[prev_id]["children"].append(node_id)
+            prev_id = node_id
+            messages_written += 1
+
+        conversations.append(
+            {
+                "title": f"Claude Code Session {session_id[:8]}",
+                "create_time": create_time,
+                "update_time": update_time,
+                "conversation_id": session_id,
+                "mapping": mapping,
+            }
+        )
+
+    output_bundle.mkdir(parents=True, exist_ok=True)
+    (output_bundle / "conversations.json").write_text(
+        json.dumps(conversations, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    (output_bundle / "user.json").write_text(json.dumps({}, ensure_ascii=False), encoding="utf-8")
+
+    return {
+        "input_paths": [str(p) for p in input_paths],
+        "output_bundle": str(output_bundle),
+        "files_scanned": len(files),
+        "lines_total": lines_total,
+        "conversations_written": len(conversations),
+        "messages_written": messages_written,
+        "skipped_invalid_lines": skipped_invalid,
+        "skipped_sidechain_events": skipped_sidechain,
+        "skipped_empty_sessions": skipped_empty_session,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "input_paths",
+        nargs="+",
+        type=Path,
+        help="One or more directories or .jsonl files containing Claude Code session data",
+    )
+    parser.add_argument(
+        "output_bundle",
+        type=Path,
+        help="Output bundle directory (will contain conversations.json + user.json)",
+    )
+    parser.add_argument(
+        "--include-sidechains",
+        action="store_true",
+        help="Keep subagent (sidechain) events instead of skipping them",
+    )
+    parser.add_argument("--json", action="store_true", help="Machine-readable output")
+    args = parser.parse_args()
+
+    try:
+        result = convert_directory(
+            args.input_paths,
+            args.output_bundle,
+            include_sidechains=args.include_sidechains,
+        )
+    except (FileNotFoundError, ValueError, NotADirectoryError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Scanned: {result['files_scanned']} files ({result['lines_total']} lines)")
+        print(
+            f"Wrote:   {result['conversations_written']} conversations "
+            f"({result['messages_written']} messages)"
+        )
+        print(
+            f"Skipped: {result['skipped_invalid_lines']} invalid, "
+            f"{result['skipped_sidechain_events']} sidechain, "
+            f"{result['skipped_empty_sessions']} empty"
+        )
+        print(f"Bundle:  {result['output_bundle']}")
+        print()
+        print(
+            "Next: cce provider import --provider chatgpt --source-path {}".format(
+                result["output_bundle"]
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_claude_code_to_bundle.py
+++ b/tests/test_claude_code_to_bundle.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from claude_code_to_bundle import (  # noqa: E402
+    _ensure_timestamp,
+    _extract_parts,
+    _normalize_role,
+    convert_directory,
+    discover_input_files,
+)
+
+from conversation_corpus_engine.import_chatgpt_export_corpus import (  # noqa: E402
+    import_chatgpt_export_corpus,
+)
+
+SESSION_A = "aaaaaaaa-1111-2222-3333-444444444444"
+SESSION_B = "bbbbbbbb-5555-6666-7777-888888888888"
+
+
+def _user_event(
+    text: str,
+    *,
+    session_id: str = SESSION_A,
+    uuid: str = "",
+    timestamp: str = "2026-06-05T19:50:52.002Z",
+    sidechain: bool = False,
+) -> dict:
+    return {
+        "type": "user",
+        "isSidechain": sidechain,
+        "sessionId": session_id,
+        "timestamp": timestamp,
+        "uuid": uuid or f"u-{abs(hash((text, session_id, timestamp))):x}",
+        "message": {"role": "user", "content": text},
+    }
+
+
+def _assistant_event(
+    blocks: list[dict],
+    *,
+    session_id: str = SESSION_A,
+    uuid: str = "",
+    timestamp: str = "2026-06-05T19:51:00.000Z",
+    sidechain: bool = False,
+) -> dict:
+    return {
+        "type": "assistant",
+        "isSidechain": sidechain,
+        "sessionId": session_id,
+        "timestamp": timestamp,
+        "uuid": uuid or f"a-{abs(hash((str(blocks), session_id, timestamp))):x}",
+        "message": {"role": "assistant", "content": blocks},
+    }
+
+
+def _write_jsonl(directory: Path, name: str, events: list) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text(
+        "\n".join(json.dumps(ev, ensure_ascii=False) for ev in events) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+class HelpersTests(unittest.TestCase):
+    def test_ensure_timestamp_parses_iso_zulu(self) -> None:
+        ts = _ensure_timestamp("2026-06-05T19:50:52.002Z")
+        self.assertGreater(ts, 0)
+
+    def test_ensure_timestamp_parses_offset_and_epoch(self) -> None:
+        self.assertGreater(_ensure_timestamp("2026-06-05T19:50:52+00:00"), 0)
+        self.assertEqual(_ensure_timestamp(1750000000), 1750000000.0)
+        self.assertEqual(_ensure_timestamp(1750000000.5), 1750000000.5)
+
+    def test_ensure_timestamp_handles_garbage(self) -> None:
+        self.assertEqual(_ensure_timestamp(None), 0.0)
+        self.assertEqual(_ensure_timestamp(""), 0.0)
+        self.assertEqual(_ensure_timestamp("not a date"), 0.0)
+        self.assertEqual(_ensure_timestamp(["nope"]), 0.0)
+
+    def test_normalize_role(self) -> None:
+        self.assertEqual(_normalize_role("user"), "user")
+        self.assertEqual(_normalize_role("Human"), "user")
+        self.assertEqual(_normalize_role("assistant"), "assistant")
+        self.assertEqual(_normalize_role("Claude"), "assistant")
+        self.assertEqual(_normalize_role(None), "user")
+        self.assertEqual(_normalize_role("weird"), "user")
+
+    def test_extract_parts_string_is_verbatim(self) -> None:
+        raw = "  spaced  \n\tprompt — with unicode ✓ and trailing space \n"
+        self.assertEqual(_extract_parts(raw), [raw])
+
+    def test_extract_parts_skips_blank_string(self) -> None:
+        self.assertEqual(_extract_parts("   \n  "), [])
+        self.assertEqual(_extract_parts(None), [])
+        self.assertEqual(_extract_parts(42), [])
+
+    def test_extract_parts_keeps_text_blocks_skips_others(self) -> None:
+        blocks = [
+            {"type": "thinking", "thinking": "internal reasoning"},
+            {"type": "text", "text": "visible answer"},
+            {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+            {"type": "tool_result", "content": "file1\nfile2"},
+            {"type": "text", "text": "second paragraph"},
+        ]
+        self.assertEqual(_extract_parts(blocks), ["visible answer", "second paragraph"])
+
+
+class ConvertDirectoryTests(unittest.TestCase):
+    def test_builds_linear_mapping_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "in"
+            output = Path(tmpdir) / "out"
+            events = [
+                {"type": "mode", "mode": "normal", "sessionId": SESSION_A},
+                _user_event("Hello", timestamp="2026-06-05T10:00:00Z"),
+                _assistant_event(
+                    [{"type": "text", "text": "Hi back"}],
+                    timestamp="2026-06-05T10:00:05Z",
+                ),
+                _user_event("Tell me more", timestamp="2026-06-05T10:00:10Z"),
+            ]
+            _write_jsonl(input_dir, f"{SESSION_A}.jsonl", events)
+
+            result = convert_directory([input_dir], output)
+            self.assertEqual(result["conversations_written"], 1)
+            self.assertEqual(result["messages_written"], 3)
+
+            convs = json.loads((output / "conversations.json").read_text(encoding="utf-8"))
+            self.assertEqual(len(convs), 1)
+            conv = convs[0]
+            self.assertEqual(conv["conversation_id"], SESSION_A)
+            self.assertEqual(conv["title"], f"Claude Code Session {SESSION_A[:8]}")
+
+            mapping = conv["mapping"]
+            self.assertEqual(len(mapping), 4)  # 1 root + 3 message nodes
+            roots = [n for n in mapping.values() if n["parent"] is None]
+            self.assertEqual(len(roots), 1)
+            root = roots[0]
+            self.assertIsNone(root["message"])
+            self.assertEqual(len(root["children"]), 1)
+
+            cur = mapping[root["children"][0]]
+            self.assertEqual(cur["message"]["author"]["role"], "user")
+            self.assertEqual(cur["message"]["content"]["parts"], ["Hello"])
+            cur = mapping[cur["children"][0]]
+            self.assertEqual(cur["message"]["author"]["role"], "assistant")
+            self.assertEqual(cur["message"]["content"]["parts"], ["Hi back"])
+            cur = mapping[cur["children"][0]]
+            self.assertEqual(cur["message"]["author"]["role"], "user")
+            self.assertEqual(cur["children"], [])
+
+            self.assertTrue((output / "user.json").exists())
+
+    def test_user_prompt_text_is_byte_identical(self) -> None:
+        prompt = "PACKET — Builder.\n\n  indented   block\t\ttabs\ntrailing space \nunicode: ✓→σ\n"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "in"
+            output = Path(tmpdir) / "out"
+            _write_jsonl(input_dir, f"{SESSION_A}.jsonl", [_user_event(prompt)])
+
+            convert_directory([input_dir], output)
+            convs = json.loads((output / "conversations.json").read_text(encoding="utf-8"))
+            mapping = convs[0]["mapping"]
+            nodes = [n for n in mapping.values() if n["message"] is not None]
+            self.assertEqual(len(nodes), 1)
+            self.assertEqual(nodes[0]["message"]["content"]["parts"], [prompt])
+
+    def test_skips_sidechain_events_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "in"
+            events = [
+                _user_event("main thread", timestamp="2026-06-05T10:00:00Z"),
+                _user_event(
+                    "subagent packet",
+                    timestamp="2026-06-05T10:00:01Z",
+                    sidechain=True,
+                ),
+            ]
+            _write_jsonl(input_dir, f"{SESSION_A}.jsonl", events)
+
+            result = convert_directory([input_dir], Path(tmpdir) / "out")
+            self.assertEqual(result["messages_written"], 1)
+            self.assertEqual(result["skipped_sidechain_events"], 1)
+
+            result_inc = convert_directory(
+                [input_dir], Path(tmpdir) / "out2", include_sidechains=True
+            )
+            self.assertEqual(result_inc["messages_written"], 2)
+            self.assertEqual(result_inc["skipped_sidechain_events"], 0)
+
+    def test_skips_tool_result_only_user_events(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "in"
+            tool_result_event = {
+                "type": "user",
+                "isSidechain": False,
+                "sessionId": SESSION_A,
+                "timestamp": "2026-06-05T10:00:02Z",
+                "uuid": "tool-result-1",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "content": "stdout noise", "tool_use_id": "t1"}
+                    ],
+                },
+            }
+            events = [
+                _user_event("real prompt", timestamp="2026-06-05T10:00:00Z"),
+                tool_result_event,
+            ]
+            _write_jsonl(input_dir, f"{SESSION_A}.jsonl", events)
+
+            result = convert_directory([input_dir], Path(tmpdir) / "out")
+            self.assertEqual(result["messages_written"], 1)
+
+    def test_dedupes_replayed_events_by_uuid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "in"
+            ev = _user_event("once only", uuid="fixed-uuid-1")
+            _write_jsonl(input_dir, f"{SESSION_A}.jsonl", [ev, ev])
+            # Resumed-session file replaying the same event uuid
+            _write_jsonl(input_dir, "resume.jsonl", [ev])
+
+            result = convert_directory([input_dir], Path(tmpdir) / "out")
+            self.assertEqual(result["conversations_written"], 1)
+            self.assertEqual(result["messages_written"], 1)
+
+    def test_groups_by_session_id_across_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "in"
+            _write_jsonl(
+                input_dir,
+                f"{SESSION_A}.jsonl",
+                [_user_event("session a", uuid="ev-a")],
+            )
+            _write_jsonl(
+                input_dir,
+                f"{SESSION_B}.jsonl",
+                [_user_event("session b", session_id=SESSION_B, uuid="ev-b")],
+            )
+
+            result = convert_directory([input_dir], Path(tmpdir) / "out")
+            self.assertEqual(result["conversations_written"], 2)
+            convs = json.loads(
+                (Path(tmpdir) / "out" / "conversations.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                sorted(c["conversation_id"] for c in convs), sorted([SESSION_A, SESSION_B])
+            )
+
+    def test_session_id_falls_back_to_file_stem_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "in"
+            ev = _user_event("orphan")
+            del ev["sessionId"]
+            _write_jsonl(input_dir, "orphan-file.jsonl", [ev])
+
+            result = convert_directory([input_dir], Path(tmpdir) / "out")
+            self.assertEqual(result["conversations_written"], 1)
+            convs = json.loads(
+                (Path(tmpdir) / "out" / "conversations.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(len(convs[0]["conversation_id"]), 36)
+
+    def test_orders_messages_by_timestamp(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "in"
+            events = [
+                _user_event("second", uuid="ev-2", timestamp="2026-06-05T10:00:10Z"),
+                _user_event("first", uuid="ev-1", timestamp="2026-06-05T10:00:00Z"),
+            ]
+            _write_jsonl(input_dir, f"{SESSION_A}.jsonl", events)
+
+            convert_directory([input_dir], Path(tmpdir) / "out")
+            convs = json.loads(
+                (Path(tmpdir) / "out" / "conversations.json").read_text(encoding="utf-8")
+            )
+            mapping = convs[0]["mapping"]
+            root = next(n for n in mapping.values() if n["parent"] is None)
+            first = mapping[root["children"][0]]
+            self.assertEqual(first["message"]["content"]["parts"], ["first"])
+            second = mapping[first["children"][0]]
+            self.assertEqual(second["message"]["content"]["parts"], ["second"])
+
+    def test_skips_invalid_lines_and_non_conversation_types(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "in"
+            input_dir.mkdir(parents=True)
+            path = input_dir / f"{SESSION_A}.jsonl"
+            lines = [
+                "not json at all {{{",
+                json.dumps({"type": "file-history-snapshot", "snapshot": {}}),
+                json.dumps({"type": "system", "content": "hook output"}),
+                json.dumps(["a", "bare", "list"]),
+                json.dumps(_user_event("kept", uuid="ev-k")),
+            ]
+            path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+            result = convert_directory([input_dir], Path(tmpdir) / "out")
+            self.assertEqual(result["skipped_invalid_lines"], 2)
+            self.assertEqual(result["messages_written"], 1)
+
+    def test_raises_on_no_input_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "in"
+            input_dir.mkdir()
+            with self.assertRaises(FileNotFoundError):
+                convert_directory([input_dir], Path(tmpdir) / "out")
+
+    def test_raises_when_no_conversation_events(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "in"
+            _write_jsonl(
+                input_dir,
+                "meta-only.jsonl",
+                [{"type": "mode", "mode": "normal", "sessionId": SESSION_A}],
+            )
+            with self.assertRaises(ValueError):
+                convert_directory([input_dir], Path(tmpdir) / "out")
+
+    def test_discover_accepts_files_and_dirs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "in"
+            input_dir.mkdir()
+            (input_dir / "b.jsonl").write_text("{}", encoding="utf-8")
+            (input_dir / "a.jsonl").write_text("{}", encoding="utf-8")
+            (input_dir / "notes.json").write_text("{}", encoding="utf-8")
+            lone = Path(tmpdir) / "lone.jsonl"
+            lone.write_text("{}", encoding="utf-8")
+
+            files = discover_input_files([input_dir, lone])
+            self.assertEqual([f.name for f in files], ["a.jsonl", "b.jsonl", "lone.jsonl"])
+
+
+class EndToEndIntegrationTests(unittest.TestCase):
+    """Verify the converter's bundle is ingestible by the standard adapter."""
+
+    def test_converter_output_imports_cleanly(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_dir = Path(tmpdir) / "transcripts"
+            events = [
+                {"type": "permission-mode", "permissionMode": "plan", "sessionId": SESSION_A},
+                _user_event(
+                    "What is the capital of France?",
+                    uuid="e2e-1",
+                    timestamp="2026-06-05T10:00:00Z",
+                ),
+                _assistant_event(
+                    [
+                        {"type": "thinking", "thinking": "easy one"},
+                        {"type": "text", "text": "Paris."},
+                    ],
+                    uuid="e2e-2",
+                    timestamp="2026-06-05T10:00:05Z",
+                ),
+                _user_event(
+                    "Tell me one historical fact about it that surprises tourists.",
+                    uuid="e2e-3",
+                    timestamp="2026-06-05T10:00:10Z",
+                ),
+                _assistant_event(
+                    [
+                        {
+                            "type": "text",
+                            "text": "The Louvre was originally a fortress built in 1190.",
+                        }
+                    ],
+                    uuid="e2e-4",
+                    timestamp="2026-06-05T10:00:15Z",
+                ),
+            ]
+            _write_jsonl(input_dir, f"{SESSION_A}.jsonl", events)
+
+            bundle = Path(tmpdir) / "bundle"
+            output = Path(tmpdir) / "corpus"
+
+            convert_directory([input_dir], bundle)
+            result = import_chatgpt_export_corpus(bundle, output, corpus_id="integration-test")
+
+            self.assertEqual(result["thread_count"], 1)
+            self.assertGreaterEqual(result["pair_count"], 1)
+            # Federation artifacts produced
+            self.assertTrue((output / "corpus" / "threads-index.json").exists())
+            self.assertTrue((output / "corpus" / "pairs-index.json").exists())
+            self.assertTrue((output / "corpus" / "contract.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #36 (engine reconciliation — Claude Code ingestion).

## What it does

Adds `scripts/claude_code_to_bundle.py`, a pre-converter modeled on `scripts/codex_to_bundle.py`. It converts Claude Code session transcripts (`~/.claude/projects/<scope-slug>/<session-uuid>.jsonl`, one JSON event per line) into the standard ChatGPT-export bundle (`conversations.json` + `user.json`) that `import_chatgpt_export_corpus` / `cce provider import --provider chatgpt` already ingests.

Behavior:
- **Verbatim rule:** user prompt text passes through byte-identical — no trimming, no whitespace normalization (emptiness checks operate on a stripped copy only).
- Assistant `text` blocks kept; `thinking` / `tool_use` / `tool_result` / image blocks skipped (no conversational corpus text).
- Sidechain (subagent) events skipped by default; `--include-sidechains` keeps them.
- Dedup by native event `uuid` (handles resumed-session replays), content-hash fallback.
- Groups events by `sessionId` (file-stem hash fallback), stable timestamp ordering with carry-forward for unstamped events, linear root→child mapping tree identical in shape to the codex converter's output.

Parsing logic ported from the session-meta ingest twin's Claude Code adapter (read-only reference).

## Acceptance output summary

Converted 3 real transcripts (2 from the limen scope, 1 from the diagnostics scope):

```
Scanned: 3 files (1763 lines)
Wrote:   3 conversations (142 messages)
Skipped: 0 invalid, 0 sidechain, 0 empty
```

Verbatim verification against source: 12/12 user prompts byte-identical in the bundle.

Full engine import path (scratch project root, bundle at `<drop>/chatgpt/inbox/`):

```
cce provider import --provider chatgpt --source-drop-root <drop> --project-root <scratch> --register --build
-> thread_count: 3, pair_count: 51, action_count: 18, empty_conversation_count: 0
-> corpus registered, federation build completed (registry.json, families-index.json, ...)
```

Tests: 20 new tests in `tests/test_claude_code_to_bundle.py` (helpers, mapping tree, verbatim pass-through, sidechain/tool_result skipping, uuid dedup, ordering, end-to-end import through `import_chatgpt_export_corpus`). Full suite: **331 passed**. `ruff check` + `ruff format --check` clean.

**Do not merge — conductor decision.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a Claude Code transcript pre-converter that produces ChatGPT-export compatible bundles for ingestion by the existing corpus import pipeline.

New Features:
- Introduce claude_code_to_bundle script to convert Claude Code JSONL session transcripts into standard ChatGPT-export style bundles.
- Provide a CLI interface to run the converter over one or more transcript paths with optional inclusion of sidechain events and JSON summary output.

Tests:
- Add comprehensive unit and integration tests covering timestamp handling, role normalization, content extraction, session grouping/deduplication, sidechain and tool-result skipping, file discovery, error conditions, and end-to-end import via the existing ChatGPT export adapter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added converter utility to transform Claude Code conversation transcripts into ChatGPT-compatible import bundle format for seamless data interoperability and migration workflows.

* **Tests**  
  * Added comprehensive test suite covering converter functionality: timestamp parsing, role normalization, message extraction, event deduplication, session grouping, file discovery, error handling, and end-to-end integration verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->