### PR TITLE
[limen LIMEN-099] IRF-CCE-033: Execute CCE commercial architecture — H1 actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,24 @@ It owns:
 - provider refresh orchestration across import, evaluation, candidate staging, and optional promotion
 - publishable JSON schemas and repo-native artifact validation
 - Meta/MCP-facing surface manifests and export bundles
+- read-only MCP stdio tools for corpus search and provider readiness
+- commercial H1 readiness contracts for the ORGAN-II surface bridge
 
 It does not own raw intake routing or system-wide discovery contracts. Those belong in Meta integrations such as `alchemia-ingestvm`, `schema-definitions`, `organvm-engine`, and `organvm-mcp-server`.
 
 ## Install
 
+For local development:
+
 ```bash
 pip install -e ".[dev]"
+```
+
+For MCP clients:
+
+```bash
+pipx install "conversation-corpus-engine[mcp]"
+cce-mcp --project-root /path/to/project
 ```
 
 ## License
@@ -53,6 +64,8 @@ cce schema validate corpus-contract --path /path/to/corpus/contract.json
 cce surface manifest --project-root /path/to/project --source-drop-root /path/to/source-drop
 cce surface context --project-root /path/to/project --source-drop-root /path/to/source-drop
 cce surface bundle --project-root /path/to/project --source-drop-root /path/to/source-drop
+cce mcp serve --project-root /path/to/project
+cce commercial h1 --project-root /path/to/project --source-drop-root /path/to/source-drop --write
 cce source-policy set --project-root /path/to/project --provider claude --primary-root /path/to/corpus --primary-corpus-id claude-local-session-memory
 cce policy replay --project-root /path/to/project --set-threshold max_stale_corpora=1 --write
 cce policy stage --project-root /path/to/project --set-threshold max_stale_corpora=1 --note "allow one stale corpus during migration"
@@ -84,6 +97,8 @@ cce source freshness /path/to/corpus
 - `src/conversation_corpus_engine/provider_readiness.py` — provider lane readiness and report writing
 - `src/conversation_corpus_engine/schema_validation.py` — published schema catalog and lightweight JSON validation
 - `src/conversation_corpus_engine/surface_exports.py` — Meta/MCP-facing manifest and context export layer
+- `src/conversation_corpus_engine/mcp_server.py` — read-only MCP stdio server for federated search and readiness tools
+- `src/conversation_corpus_engine/commercial_architecture.py` — commercial H1 readiness and bridge-contract artifacts
 - `src/conversation_corpus_engine/schemas/` — installable JSON-schema contracts for canonical artifacts
 - `src/conversation_corpus_engine/evaluation.py` — seeded/manual evaluation, scorecards, and regression gates
 - `src/conversation_corpus_engine/evaluation_bootstrap.py` — provider-aware evaluation bootstrap and report generation
@@ -99,6 +114,8 @@ cce source freshness /path/to/corpus
 
 Runtime state is written to `state/`, `federation/`, and `reports/`. Those directories are intentionally ignored so the repo stays focused on canonical code, contracts, tests, and public documentation.
 
+Commercial H1 readiness is written under `reports/commercial/` when `cce commercial h1 --write` is used. The generated contract separates repo-owned readiness from external actions such as PyPI upload, Hacker News posting, ORGAN-II repo creation, landing-page publishing, and paid-tier enablement.
+
 ## Status
 
-This repo now serves as the canonical Organ I home of the conversation corpus system. The adjacent Meta consumer path is also live: `schema-definitions` canonizes the outward contracts, `organvm-engine` discovers and validates emitted surface bundles, and `organvm-mcp-server` exposes them to agent sessions. Operational hardening is underway: CI gates all pushes, ChatGPT is a first-class provider alongside Claude/Gemini/Grok/Perplexity/Copilot, and sanitized test fixtures document the expected export formats. The next frontier is downstream dashboard consumption and additional provider adapters.
+This repo now serves as the canonical Organ I home of the conversation corpus system. The adjacent Meta consumer path is also live: `schema-definitions` canonizes the outward contracts, `organvm-engine` discovers and validates emitted surface bundles, and `organvm-mcp-server` exposes them to agent sessions. CCE also exposes its own read-only MCP stdio server and an H1 commercial readiness contract for the `conversation-corpus--surfaces` bridge. Operational hardening is underway: CI gates all pushes, ChatGPT is a first-class provider alongside Claude/Gemini/Grok/Perplexity/Copilot, and sanitized test fixtures document the expected export formats. The next frontier is downstream dashboard consumption, ORGAN-II surface creation, and additional provider adapters.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,18 +6,32 @@ build-backend = "setuptools.build_meta"
 name = "conversation-corpus-engine"
 version = "0.3.0"
 description = "Canonical corpus and federation engine for multi-provider AI conversation memory."
+readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
 dependencies = []
+keywords = ["ai", "conversation", "corpus", "federation", "mcp"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Text Processing :: Indexing",
+]
 
 [project.urls]
 Repository = "https://github.com/organvm-i-theoria/conversation-corpus-engine"
 
 [project.optional-dependencies]
 dev = ["pytest>=9.0.3", "ruff>=0.4"]
+mcp = []
 
 [project.scripts]
 cce = "conversation_corpus_engine.cli:main"
+cce-mcp = "conversation_corpus_engine.mcp_server:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/conversation_corpus_engine/cli.py
+++ b/src/conversation_corpus_engine/cli.py
@@ -14,6 +14,11 @@ from .chatgpt_local_session import (
     set_project_route,
     sync_chatgpt_projects,
 )
+from .commercial_architecture import (
+    build_commercial_h1_readiness,
+    render_commercial_h1_readiness,
+    write_commercial_h1_artifacts,
+)
 from .corpus_candidates import (
     corpus_candidate_history_path,
     load_corpus_candidate_manifest,
@@ -39,6 +44,7 @@ from .governance_candidates import (
 )
 from .governance_policy import load_or_create_promotion_policy
 from .governance_replay import build_policy_replay_payload, write_policy_replay_artifacts
+from .mcp_server import serve_stdio as serve_mcp_stdio
 from .migration import seed_registry_from_staging
 from .paths import default_project_root
 from .persona_extract import extract_persona_lexicon, write_persona_extract_artifacts
@@ -334,6 +340,22 @@ def build_parser() -> argparse.ArgumentParser:
     )
     surface_bundle.add_argument("--project-root", type=Path, default=default_project_root())
     surface_bundle.add_argument("--source-drop-root", type=Path)
+
+    mcp = subparsers.add_parser("mcp", help="Serve read-only CCE tools over MCP")
+    mcp_sub = mcp.add_subparsers(dest="action", required=True)
+    mcp_serve = mcp_sub.add_parser("serve", help="Run the stdio MCP server")
+    mcp_serve.add_argument("--project-root", type=Path, default=default_project_root())
+
+    commercial = subparsers.add_parser("commercial", help="Commercial architecture readiness")
+    commercial_sub = commercial.add_subparsers(dest="action", required=True)
+    commercial_h1 = commercial_sub.add_parser(
+        "h1",
+        help="Build the commercial H1 readiness contract and external action ledger",
+    )
+    commercial_h1.add_argument("--project-root", type=Path, default=default_project_root())
+    commercial_h1.add_argument("--source-drop-root", type=Path)
+    commercial_h1.add_argument("--write", action="store_true")
+    commercial_h1.add_argument("--json", action="store_true")
 
     source_policy = subparsers.add_parser(
         "source-policy", help="Manage provider source authority policies"
@@ -955,6 +977,30 @@ def main() -> None:
             source_drop_root=args.source_drop_root,
         )
         print(json.dumps(payload, indent=2))
+        return
+
+    if args.group == "mcp" and args.action == "serve":
+        serve_mcp_stdio(project_root=args.project_root)
+        return
+
+    if args.group == "commercial" and args.action == "h1":
+        payload = build_commercial_h1_readiness(
+            args.project_root,
+            source_drop_root=args.source_drop_root,
+        )
+        artifacts: dict[str, str] = {}
+        if args.write:
+            artifacts = write_commercial_h1_artifacts(args.project_root, payload)
+            payload = {**payload, "artifacts_written": artifacts}
+        if args.json:
+            print(json.dumps(payload, indent=2))
+            return
+        print(render_commercial_h1_readiness(payload))
+        if artifacts:
+            print("")
+            print("Artifacts:")
+            for path in artifacts.values():
+                print(f"- {path}")
         return
 
     if args.group == "source-policy" and args.action == "show":

--- a/src/conversation_corpus_engine/commercial_architecture.py
+++ b/src/conversation_corpus_engine/commercial_architecture.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+import tomllib
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from . import __version__
+from .answering import write_json, write_markdown
+from .paths import REPO_ROOT
+from .provider_catalog import default_source_drop_root
+from .surface_exports import (
+    mcp_context_json_path,
+    surface_bundle_json_path,
+    surface_manifest_json_path,
+)
+
+COMMERCIAL_H1_CONTRACT = "conversation-corpus-engine-commercial-h1-readiness-v1"
+COMMERCIAL_H1_CONTRACT_VERSION = 1
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def commercial_reports_dir(project_root: Path) -> Path:
+    return project_root.resolve() / "reports" / "commercial"
+
+
+def commercial_h1_json_path(project_root: Path) -> Path:
+    return commercial_reports_dir(project_root) / "commercial-h1-readiness.json"
+
+
+def commercial_h1_markdown_path(project_root: Path) -> Path:
+    return commercial_reports_dir(project_root) / "commercial-h1-readiness.md"
+
+
+def load_pyproject_metadata() -> dict[str, Any]:
+    pyproject_path = REPO_ROOT / "pyproject.toml"
+    payload = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    project = payload.get("project") or {}
+    return {
+        "path": str(pyproject_path),
+        "name": project.get("name"),
+        "version": project.get("version"),
+        "description": project.get("description"),
+        "readme": project.get("readme"),
+        "requires_python": project.get("requires-python"),
+        "dependencies": project.get("dependencies") or [],
+        "optional_dependencies": project.get("optional-dependencies") or {},
+        "scripts": project.get("scripts") or {},
+        "urls": project.get("urls") or {},
+    }
+
+
+def package_readiness(metadata: dict[str, Any]) -> dict[str, Any]:
+    scripts = metadata.get("scripts") or {}
+    optional_dependencies = metadata.get("optional_dependencies") or {}
+    checks = {
+        "has_name": bool(metadata.get("name")),
+        "has_version": metadata.get("version") == __version__,
+        "has_description": bool(metadata.get("description")),
+        "has_readme": bool(metadata.get("readme")),
+        "has_repository_url": bool((metadata.get("urls") or {}).get("Repository")),
+        "has_cli_script": scripts.get("cce") == "conversation_corpus_engine.cli:main",
+        "has_mcp_script": scripts.get("cce-mcp") == "conversation_corpus_engine.mcp_server:main",
+        "has_mcp_extra": "mcp" in optional_dependencies,
+    }
+    return {
+        "checks": checks,
+        "pypi_ready": all(
+            checks[key]
+            for key in (
+                "has_name",
+                "has_version",
+                "has_description",
+                "has_readme",
+                "has_repository_url",
+                "has_cli_script",
+            )
+        ),
+        "mcp_distribution_ready": all(
+            checks[key] for key in ("has_cli_script", "has_mcp_script", "has_mcp_extra")
+        ),
+    }
+
+
+def build_signal_chain(project_root: Path) -> list[dict[str, str]]:
+    return [
+        {
+            "from": "external",
+            "signal": "ARCHIVE_PACKET",
+            "to": "conversation-corpus-engine",
+            "artifact": "provider export or local-session source",
+        },
+        {
+            "from": "conversation-corpus-engine",
+            "signal": "ANNOTATED_CORPUS",
+            "to": "conversation-corpus-engine",
+            "artifact": str(project_root / "corpus"),
+        },
+        {
+            "from": "conversation-corpus-engine",
+            "signal": "VALIDATION_RECORD",
+            "to": "conversation-corpus--surfaces",
+            "artifact": str(surface_manifest_json_path(project_root)),
+        },
+        {
+            "from": "conversation-corpus-engine",
+            "signal": "STATE_MODEL",
+            "to": "conversation-corpus--surfaces",
+            "artifact": str(mcp_context_json_path(project_root)),
+        },
+        {
+            "from": "conversation-corpus--surfaces",
+            "signal": "INTERFACE_CONTRACT",
+            "to": "conversation-corpus--product",
+            "artifact": "landing page, SDK, MCP packaging, API gateway",
+        },
+        {
+            "from": "conversation-corpus--product",
+            "signal": "STATE_MODEL:billing",
+            "to": "customer",
+            "artifact": "pricing, subscription, invoice, usage state",
+        },
+    ]
+
+
+def build_interface_contract(project_root: Path) -> dict[str, Any]:
+    return {
+        "source_organ": "ORGAN-I",
+        "source_repo": "conversation-corpus-engine",
+        "target_organ": "ORGAN-II",
+        "target_repo": "conversation-corpus--surfaces",
+        "formation_type": "FORM",
+        "consumes": ["STATE_MODEL", "VALIDATION_RECORD"],
+        "expected_output_signal": "INTERFACE_CONTRACT",
+        "unidirectional_flow": ["ORGAN-I", "ORGAN-II", "ORGAN-III"],
+        "engine_artifacts": {
+            "surface_manifest": str(surface_manifest_json_path(project_root)),
+            "mcp_context": str(mcp_context_json_path(project_root)),
+            "surface_bundle": str(surface_bundle_json_path(project_root)),
+        },
+        "downstream_contains": [
+            "landing page with email capture",
+            "Python SDK wrapper",
+            "MCP server packaging",
+            "API gateway",
+            "web app shell",
+        ],
+    }
+
+
+def h1_actions(package_status: dict[str, Any]) -> list[dict[str, Any]]:
+    pypi_ready = bool(package_status["pypi_ready"])
+    mcp_ready = bool(package_status["mcp_distribution_ready"])
+    return [
+        {
+            "id": "h1-pypi-package",
+            "title": "Push cce to PyPI with clean README",
+            "status": "ready" if pypi_ready else "needs_repo_work",
+            "repo_owned": True,
+            "evidence": [
+                "pyproject includes package metadata, README, repository URL, and cce CLI script."
+            ],
+            "next_action": "Build and upload the approved distribution from a release environment.",
+        },
+        {
+            "id": "h1-mcp-server",
+            "title": "Package MCP server as pipx install cce[mcp]",
+            "status": "ready" if mcp_ready else "needs_repo_work",
+            "repo_owned": True,
+            "evidence": [
+                "mcp optional extra is declared.",
+                "cce-mcp script exposes the stdio MCP server.",
+                "cce mcp serve provides the same server through the main CLI.",
+            ],
+            "next_action": 'Install with pipx install "conversation-corpus-engine[mcp]".',
+        },
+        {
+            "id": "h1-show-hn",
+            "title": 'Post on Hacker News: "Show HN: Search all your AI conversations from one place"',
+            "status": "external_action_required",
+            "repo_owned": False,
+            "evidence": ["Message and product claim are captured in the H1 readiness contract."],
+            "next_action": "Post from the operator account after package install smoke test passes.",
+        },
+        {
+            "id": "h1-surfaces-repo",
+            "title": "Create conversation-corpus--surfaces repo as ORGAN-II bridge",
+            "status": "external_action_required",
+            "repo_owned": False,
+            "evidence": [
+                "CCE emits surface-manifest, mcp-context, and surface-bundle artifacts.",
+                "This contract defines the STATE_MODEL + VALIDATION_RECORD inputs.",
+            ],
+            "next_action": "Create the ORGAN-II repo and consume the exported CCE surface bundle.",
+        },
+        {
+            "id": "h1-landing-page",
+            "title": "Create landing page with email capture",
+            "status": "external_action_required",
+            "repo_owned": False,
+            "evidence": ["Landing page belongs in conversation-corpus--surfaces."],
+            "next_action": "Publish a one-page Loop 1 memory offer with email capture.",
+        },
+        {
+            "id": "h1-lobehub-paid-tiers",
+            "title": "Enable a-i--skills paid tiers on LobeHub",
+            "status": "external_action_required",
+            "repo_owned": False,
+            "evidence": ["Paid-tier switch is outside the CCE repository boundary."],
+            "next_action": "Enable tiers in the a-i--skills/LobeHub distribution channel.",
+        },
+    ]
+
+
+def build_commercial_h1_readiness(
+    project_root: Path,
+    *,
+    source_drop_root: Path | None = None,
+) -> dict[str, Any]:
+    resolved_project_root = project_root.resolve()
+    resolved_source_drop_root = (
+        source_drop_root or default_source_drop_root(resolved_project_root)
+    ).resolve()
+    package_metadata = load_pyproject_metadata()
+    package_status = package_readiness(package_metadata)
+    actions = h1_actions(package_status)
+    repo_actions = [item for item in actions if item["repo_owned"]]
+    external_actions = [item for item in actions if not item["repo_owned"]]
+    repo_ready_count = sum(1 for item in repo_actions if item["status"] == "ready")
+    return {
+        "contract_name": COMMERCIAL_H1_CONTRACT,
+        "contract_version": COMMERCIAL_H1_CONTRACT_VERSION,
+        "generated_at": now_iso(),
+        "project_root": str(resolved_project_root),
+        "source_drop_root": str(resolved_source_drop_root),
+        "architecture_refs": [
+            str(REPO_ROOT / "docs/superpowers/specs/2026-03-31-cce-commercial-architecture-design.md"),
+            str(REPO_ROOT / "docs/superpowers/specs/2026-03-31-cce-commercial-architecture-expansion.md"),
+        ],
+        "summary": {
+            "horizon": "H1",
+            "repo_action_count": len(repo_actions),
+            "repo_ready_action_count": repo_ready_count,
+            "external_action_count": len(external_actions),
+            "commercial_h1_repo_ready": repo_ready_count == len(repo_actions),
+            "external_actions_remaining": len(external_actions),
+        },
+        "package": {
+            "metadata": package_metadata,
+            "readiness": package_status,
+        },
+        "mcp_distribution": {
+            "extra": "mcp",
+            "pipx_install": 'pipx install "conversation-corpus-engine[mcp]"',
+            "scripts": ["cce", "cce-mcp"],
+            "serve_command": "cce mcp serve --project-root /path/to/project",
+            "tools": ["cce_search", "cce_list_corpora", "cce_provider_readiness"],
+        },
+        "interface_contract": build_interface_contract(resolved_project_root),
+        "signal_chain": build_signal_chain(resolved_project_root),
+        "h1_actions": actions,
+        "audience_offer": {
+            "show_hn_title": "Show HN: Search all your AI conversations from one place",
+            "first_customer_segment": "AI consulting firms or AI-native startups",
+            "loop_1_offer": "Recall and search multi-provider AI conversation memory.",
+            "professional_price": "$29/mo",
+            "builder_price": "$100-500/mo",
+        },
+        "gate_evidence": {
+            "REP-001": {
+                "check": "At least 1 mechanism emits INTERFACE_CONTRACT",
+                "state": "engine-ready",
+                "evidence": "CCE emits STATE_MODEL and VALIDATION_RECORD artifacts for ORGAN-II surfaces.",
+            },
+            "REP-002": {
+                "check": "digestive--measure can metabolize TRANSACTION signals",
+                "state": "external-action-required",
+                "evidence": "Stripe belongs in conversation-corpus--product, not this ORGAN-I repo.",
+            },
+            "REP-003": {
+                "check": "At least 1 paying customer exists",
+                "state": "external-action-required",
+                "evidence": "Revenue status must be recorded after billing/product activation.",
+            },
+        },
+    }
+
+
+def render_commercial_h1_readiness(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary") or {}
+    lines = [
+        "# CCE Commercial H1 Readiness",
+        "",
+        f"- Generated: {payload.get('generated_at') or 'n/a'}",
+        f"- Repo-ready actions: {summary.get('repo_ready_action_count', 0)}/{summary.get('repo_action_count', 0)}",
+        f"- External actions remaining: {summary.get('external_actions_remaining', 0)}",
+        f"- MCP install: {(payload.get('mcp_distribution') or {}).get('pipx_install') or 'n/a'}",
+        "",
+        "## H1 Actions",
+        "",
+    ]
+    for item in payload.get("h1_actions") or []:
+        lines.append(f"- {item['id']}: {item['status']} - {item['title']}")
+        lines.append(f"  next: {item.get('next_action') or 'n/a'}")
+    lines.extend(["", "## Interface Contract", ""])
+    interface_contract = payload.get("interface_contract") or {}
+    lines.append(
+        "- "
+        + f"{interface_contract.get('source_repo')} -> {interface_contract.get('target_repo')} "
+        + f"({interface_contract.get('expected_output_signal')})"
+    )
+    lines.extend(["", "## Signal Chain", ""])
+    for item in payload.get("signal_chain") or []:
+        lines.append(f"- {item['from']} --{item['signal']}--> {item['to']}")
+    return "\n".join(lines)
+
+
+def write_commercial_h1_artifacts(
+    project_root: Path,
+    payload: dict[str, Any],
+) -> dict[str, str]:
+    json_path = commercial_h1_json_path(project_root)
+    markdown_path = commercial_h1_markdown_path(project_root)
+    write_json(json_path, payload)
+    write_markdown(markdown_path, render_commercial_h1_readiness(payload))
+    return {
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+    }

--- a/src/conversation_corpus_engine/commercial_architecture.py
+++ b/src/conversation_corpus_engine/commercial_architecture.py
@@ -237,8 +237,14 @@ def build_commercial_h1_readiness(
         "project_root": str(resolved_project_root),
         "source_drop_root": str(resolved_source_drop_root),
         "architecture_refs": [
-            str(REPO_ROOT / "docs/superpowers/specs/2026-03-31-cce-commercial-architecture-design.md"),
-            str(REPO_ROOT / "docs/superpowers/specs/2026-03-31-cce-commercial-architecture-expansion.md"),
+            str(
+                REPO_ROOT
+                / "docs/superpowers/specs/2026-03-31-cce-commercial-architecture-design.md"
+            ),
+            str(
+                REPO_ROOT
+                / "docs/superpowers/specs/2026-03-31-cce-commercial-architecture-expansion.md"
+            ),
         ],
         "summary": {
             "horizon": "H1",

--- a/src/conversation_corpus_engine/mcp_server.py
+++ b/src/conversation_corpus_engine/mcp_server.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, TextIO
+
+from . import __version__
+from .answering import render_answer_text
+from .federation import build_federated_answer, list_registered_corpora
+from .paths import default_project_root
+from .provider_catalog import default_source_drop_root
+from .provider_readiness import build_provider_readiness, render_provider_readiness_text
+
+MCP_PROTOCOL_VERSION = "2025-06-18"
+SUPPORTED_PROTOCOL_VERSIONS = {"2024-11-05", "2025-03-26", MCP_PROTOCOL_VERSION}
+SERVER_NAME = "conversation-corpus-engine"
+
+JSONRPC_PARSE_ERROR = -32700
+JSONRPC_INVALID_REQUEST = -32600
+JSONRPC_METHOD_NOT_FOUND = -32601
+JSONRPC_INVALID_PARAMS = -32602
+JSONRPC_INTERNAL_ERROR = -32603
+
+SESSION = {"project_root": default_project_root()}
+
+
+def set_session_project_root(project_root: Path) -> None:
+    SESSION["project_root"] = project_root.expanduser().resolve()
+
+
+def resolve_project_root(arguments: dict[str, Any] | None) -> Path:
+    raw_value = (arguments or {}).get("project_root")
+    if not raw_value:
+        return SESSION["project_root"]
+    return Path(str(raw_value)).expanduser().resolve()
+
+
+def text_result(text: str, structured_content: dict[str, Any] | None = None) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "content": [{"type": "text", "text": text}],
+        "isError": False,
+    }
+    if structured_content is not None:
+        result["structuredContent"] = structured_content
+    return result
+
+
+def error_tool_result(message: str, structured_content: dict[str, Any] | None = None) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "content": [{"type": "text", "text": message}],
+        "isError": True,
+    }
+    if structured_content is not None:
+        result["structuredContent"] = structured_content
+    return result
+
+
+def mcp_tools() -> list[dict[str, Any]]:
+    project_root_property = {
+        "type": "string",
+        "description": "Project root that contains CCE state, federation, and reports.",
+    }
+    return [
+        {
+            "name": "cce_search",
+            "title": "Search Federated Conversation Corpus",
+            "description": "Search registered CCE corpora and return a grounded answer dossier.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["query"],
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Natural-language query to answer from the corpus.",
+                    },
+                    "project_root": project_root_property,
+                    "mode": {
+                        "type": "string",
+                        "enum": ["family_brief", "action", "unresolved", "timeline"],
+                        "description": "Optional retrieval mode for focused ledger searches.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum retrieval results to consider.",
+                        "minimum": 1,
+                        "maximum": 25,
+                    },
+                    "corpus_id": {
+                        "type": "string",
+                        "description": "Optional registered corpus ID to search within.",
+                    },
+                },
+            },
+            "annotations": {"readOnlyHint": True},
+        },
+        {
+            "name": "cce_list_corpora",
+            "title": "List Registered Corpora",
+            "description": "List corpus registrations visible to the CCE federation registry.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "project_root": project_root_property,
+                    "active_only": {
+                        "type": "boolean",
+                        "description": "Only include active corpus registrations.",
+                    },
+                },
+            },
+            "annotations": {"readOnlyHint": True},
+        },
+        {
+            "name": "cce_provider_readiness",
+            "title": "Inspect Provider Readiness",
+            "description": "Summarize provider intake readiness for a project/source-drop pair.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "project_root": project_root_property,
+                    "source_drop_root": {
+                        "type": "string",
+                        "description": "Provider source-drop root. Defaults to the project setting.",
+                    },
+                },
+            },
+            "annotations": {"readOnlyHint": True},
+        },
+    ]
+
+
+def call_cce_search(arguments: dict[str, Any]) -> dict[str, Any]:
+    query = str(arguments.get("query") or "").strip()
+    if not query:
+        return error_tool_result("Missing required argument: query")
+    project_root = resolve_project_root(arguments)
+    raw_limit = arguments.get("limit", 8)
+    try:
+        limit = max(1, min(25, int(raw_limit)))
+    except (TypeError, ValueError):
+        return error_tool_result("Argument limit must be an integer.")
+    answer = build_federated_answer(
+        project_root,
+        query,
+        mode=arguments.get("mode"),
+        limit=limit,
+        corpus_id=arguments.get("corpus_id"),
+    )
+    return text_result(render_answer_text(answer), answer)
+
+
+def call_cce_list_corpora(arguments: dict[str, Any]) -> dict[str, Any]:
+    project_root = resolve_project_root(arguments)
+    active_only = bool(arguments.get("active_only", False))
+    corpora = list_registered_corpora(project_root, active_only=active_only)
+    payload = {
+        "project_root": str(project_root),
+        "active_only": active_only,
+        "count": len(corpora),
+        "corpora": corpora,
+    }
+    if corpora:
+        lines = [f"{item['corpus_id']}: {item['name']} [{item.get('status', 'active')}]" for item in corpora]
+    else:
+        lines = ["No registered corpora."]
+    return text_result("\n".join(lines), payload)
+
+
+def call_cce_provider_readiness(arguments: dict[str, Any]) -> dict[str, Any]:
+    project_root = resolve_project_root(arguments)
+    raw_source_drop_root = arguments.get("source_drop_root")
+    source_drop_root = (
+        Path(str(raw_source_drop_root)).expanduser().resolve()
+        if raw_source_drop_root
+        else default_source_drop_root(project_root)
+    )
+    payload = build_provider_readiness(project_root, source_drop_root)
+    return text_result(render_provider_readiness_text(payload), payload)
+
+
+def call_tool(name: str, arguments: dict[str, Any] | None = None) -> dict[str, Any]:
+    resolved_arguments = arguments or {}
+    if name == "cce_search":
+        return call_cce_search(resolved_arguments)
+    if name == "cce_list_corpora":
+        return call_cce_list_corpora(resolved_arguments)
+    if name == "cce_provider_readiness":
+        return call_cce_provider_readiness(resolved_arguments)
+    return error_tool_result(f"Unknown CCE MCP tool: {name}")
+
+
+def jsonrpc_result(request_id: Any, result: dict[str, Any]) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+
+def jsonrpc_error(
+    request_id: Any,
+    code: int,
+    message: str,
+    *,
+    data: Any | None = None,
+) -> dict[str, Any]:
+    error: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        error["data"] = data
+    return {"jsonrpc": "2.0", "id": request_id, "error": error}
+
+
+def initialize_result(params: dict[str, Any] | None = None) -> dict[str, Any]:
+    requested_version = (params or {}).get("protocolVersion")
+    protocol_version = (
+        requested_version
+        if requested_version in SUPPORTED_PROTOCOL_VERSIONS
+        else MCP_PROTOCOL_VERSION
+    )
+    return {
+        "protocolVersion": protocol_version,
+        "capabilities": {"tools": {"listChanged": False}},
+        "serverInfo": {
+            "name": SERVER_NAME,
+            "title": "Conversation Corpus Engine",
+            "version": __version__,
+        },
+        "instructions": (
+            "Use cce_search for read-only answers from registered conversation corpora. "
+            "Use cce_list_corpora and cce_provider_readiness to inspect available context."
+        ),
+    }
+
+
+def handle_jsonrpc_message(message: Any) -> dict[str, Any] | None:
+    if not isinstance(message, dict):
+        return jsonrpc_error(None, JSONRPC_INVALID_REQUEST, "Invalid JSON-RPC request.")
+    request_id = message.get("id")
+    method = message.get("method")
+    params = message.get("params") if isinstance(message.get("params"), dict) else {}
+    is_notification = "id" not in message
+    if not isinstance(method, str):
+        if is_notification:
+            return None
+        return jsonrpc_error(request_id, JSONRPC_INVALID_REQUEST, "Missing JSON-RPC method.")
+
+    if method == "notifications/initialized":
+        return None
+    if method == "initialize":
+        return jsonrpc_result(request_id, initialize_result(params))
+    if method == "ping":
+        return jsonrpc_result(request_id, {})
+    if method == "tools/list":
+        return jsonrpc_result(request_id, {"tools": mcp_tools()})
+    if method == "tools/call":
+        name = params.get("name")
+        arguments = params.get("arguments") or {}
+        if not isinstance(name, str) or not isinstance(arguments, dict):
+            return jsonrpc_error(
+                request_id,
+                JSONRPC_INVALID_PARAMS,
+                "tools/call requires string name and object arguments.",
+            )
+        try:
+            return jsonrpc_result(request_id, call_tool(name, arguments))
+        except Exception as exc:  # pragma: no cover - defensive protocol boundary
+            return jsonrpc_error(request_id, JSONRPC_INTERNAL_ERROR, str(exc))
+    if is_notification:
+        return None
+    return jsonrpc_error(request_id, JSONRPC_METHOD_NOT_FOUND, f"Unknown method: {method}")
+
+
+def serve_stdio(
+    *,
+    project_root: Path | None = None,
+    input_stream: TextIO | None = None,
+    output_stream: TextIO | None = None,
+) -> None:
+    if project_root is not None:
+        set_session_project_root(project_root)
+    stdin = input_stream or sys.stdin
+    stdout = output_stream or sys.stdout
+    for raw_line in stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError as exc:
+            response = jsonrpc_error(None, JSONRPC_PARSE_ERROR, "Parse error.", data=str(exc))
+        else:
+            response = handle_jsonrpc_message(message)
+        if response is None:
+            continue
+        stdout.write(json.dumps(response, separators=(",", ":")) + "\n")
+        stdout.flush()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Conversation Corpus Engine MCP server")
+    parser.add_argument("--project-root", type=Path, default=default_project_root())
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = build_parser().parse_args(argv)
+    serve_stdio(project_root=args.project_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/conversation_corpus_engine/mcp_server.py
+++ b/src/conversation_corpus_engine/mcp_server.py
@@ -47,7 +47,9 @@ def text_result(text: str, structured_content: dict[str, Any] | None = None) -> 
     return result
 
 
-def error_tool_result(message: str, structured_content: dict[str, Any] | None = None) -> dict[str, Any]:
+def error_tool_result(
+    message: str, structured_content: dict[str, Any] | None = None
+) -> dict[str, Any]:
     result: dict[str, Any] = {
         "content": [{"type": "text", "text": message}],
         "isError": True,
@@ -161,7 +163,10 @@ def call_cce_list_corpora(arguments: dict[str, Any]) -> dict[str, Any]:
         "corpora": corpora,
     }
     if corpora:
-        lines = [f"{item['corpus_id']}: {item['name']} [{item.get('status', 'active')}]" for item in corpora]
+        lines = [
+            f"{item['corpus_id']}: {item['name']} [{item.get('status', 'active')}]"
+            for item in corpora
+        ]
     else:
         lines = ["No registered corpora."]
     return text_result("\n".join(lines), payload)

--- a/src/conversation_corpus_engine/schema_validation.py
+++ b/src/conversation_corpus_engine/schema_validation.py
@@ -45,6 +45,10 @@ SCHEMA_CATALOG = {
         "filename": "surface-bundle.schema.json",
         "description": "Bundle of exported surface artifacts plus validation results.",
     },
+    "commercial-h1-readiness": {
+        "filename": "commercial-h1-readiness.schema.json",
+        "description": "Commercial architecture H1 readiness contract and external action ledger.",
+    },
 }
 
 

--- a/src/conversation_corpus_engine/schemas/commercial-h1-readiness.schema.json
+++ b/src/conversation_corpus_engine/schemas/commercial-h1-readiness.schema.json
@@ -1,0 +1,235 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CCE Commercial H1 Readiness",
+  "type": "object",
+  "required": [
+    "contract_name",
+    "contract_version",
+    "generated_at",
+    "project_root",
+    "source_drop_root",
+    "summary",
+    "package",
+    "mcp_distribution",
+    "interface_contract",
+    "signal_chain",
+    "h1_actions",
+    "audience_offer",
+    "gate_evidence"
+  ],
+  "properties": {
+    "contract_name": {
+      "const": "conversation-corpus-engine-commercial-h1-readiness-v1"
+    },
+    "contract_version": {
+      "type": "integer"
+    },
+    "generated_at": {
+      "type": "string"
+    },
+    "project_root": {
+      "type": "string"
+    },
+    "source_drop_root": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "horizon",
+        "repo_action_count",
+        "repo_ready_action_count",
+        "external_action_count",
+        "commercial_h1_repo_ready",
+        "external_actions_remaining"
+      ],
+      "properties": {
+        "horizon": {
+          "type": "string"
+        },
+        "repo_action_count": {
+          "type": "integer"
+        },
+        "repo_ready_action_count": {
+          "type": "integer"
+        },
+        "external_action_count": {
+          "type": "integer"
+        },
+        "commercial_h1_repo_ready": {
+          "type": "boolean"
+        },
+        "external_actions_remaining": {
+          "type": "integer"
+        }
+      }
+    },
+    "package": {
+      "type": "object",
+      "required": [
+        "metadata",
+        "readiness"
+      ],
+      "properties": {
+        "metadata": {
+          "type": "object"
+        },
+        "readiness": {
+          "type": "object",
+          "required": [
+            "checks",
+            "pypi_ready",
+            "mcp_distribution_ready"
+          ],
+          "properties": {
+            "checks": {
+              "type": "object"
+            },
+            "pypi_ready": {
+              "type": "boolean"
+            },
+            "mcp_distribution_ready": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "mcp_distribution": {
+      "type": "object",
+      "required": [
+        "extra",
+        "pipx_install",
+        "scripts",
+        "serve_command",
+        "tools"
+      ],
+      "properties": {
+        "extra": {
+          "type": "string"
+        },
+        "pipx_install": {
+          "type": "string"
+        },
+        "scripts": {
+          "type": "array"
+        },
+        "serve_command": {
+          "type": "string"
+        },
+        "tools": {
+          "type": "array"
+        }
+      }
+    },
+    "interface_contract": {
+      "type": "object",
+      "required": [
+        "source_organ",
+        "source_repo",
+        "target_organ",
+        "target_repo",
+        "formation_type",
+        "consumes",
+        "expected_output_signal",
+        "unidirectional_flow",
+        "engine_artifacts"
+      ],
+      "properties": {
+        "source_organ": {
+          "type": "string"
+        },
+        "source_repo": {
+          "type": "string"
+        },
+        "target_organ": {
+          "type": "string"
+        },
+        "target_repo": {
+          "type": "string"
+        },
+        "formation_type": {
+          "type": "string"
+        },
+        "consumes": {
+          "type": "array"
+        },
+        "expected_output_signal": {
+          "type": "string"
+        },
+        "unidirectional_flow": {
+          "type": "array"
+        },
+        "engine_artifacts": {
+          "type": "object"
+        }
+      }
+    },
+    "signal_chain": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "from",
+          "signal",
+          "to",
+          "artifact"
+        ],
+        "properties": {
+          "from": {
+            "type": "string"
+          },
+          "signal": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          },
+          "artifact": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "h1_actions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "status",
+          "repo_owned",
+          "evidence",
+          "next_action"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "repo_owned": {
+            "type": "boolean"
+          },
+          "evidence": {
+            "type": "array"
+          },
+          "next_action": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "audience_offer": {
+      "type": "object"
+    },
+    "gate_evidence": {
+      "type": "object"
+    }
+  }
+}

--- a/src/conversation_corpus_engine/schemas/surface-manifest.schema.json
+++ b/src/conversation_corpus_engine/schemas/surface-manifest.schema.json
@@ -66,6 +66,41 @@
         }
       }
     },
+    "commercial_bridge": {
+      "type": "object",
+      "required": [
+        "horizon",
+        "source_organ",
+        "target_organ",
+        "target_repo",
+        "consumes",
+        "expected_output_signal",
+        "readiness_command"
+      ],
+      "properties": {
+        "horizon": {
+          "type": "string"
+        },
+        "source_organ": {
+          "type": "string"
+        },
+        "target_organ": {
+          "type": "string"
+        },
+        "target_repo": {
+          "type": "string"
+        },
+        "consumes": {
+          "type": "array"
+        },
+        "expected_output_signal": {
+          "type": "string"
+        },
+        "readiness_command": {
+          "type": "string"
+        }
+      }
+    },
     "schemas": {
       "type": "array",
       "items": {

--- a/src/conversation_corpus_engine/surface_exports.py
+++ b/src/conversation_corpus_engine/surface_exports.py
@@ -68,6 +68,16 @@ CLI_SURFACES = [
         "purpose": "Export Meta/MCP-facing manifests from the governed project state.",
         "audience": "mcp",
     },
+    {
+        "command": "cce mcp serve --project-root /path/to/project",
+        "purpose": "Serve read-only corpus search and readiness tools over MCP stdio.",
+        "audience": "mcp",
+    },
+    {
+        "command": "cce commercial h1 --project-root /path/to/project --write",
+        "purpose": "Write the commercial H1 readiness contract and external action ledger.",
+        "audience": "commercial",
+    },
 ]
 
 
@@ -300,6 +310,17 @@ def build_surface_manifest(
             "source_drop_root": str(resolved_source_drop_root),
             "organ": "ORGAN-I",
             "system_role": "conversation-corpus-engine",
+        },
+        "commercial_bridge": {
+            "horizon": "H1",
+            "source_organ": "ORGAN-I",
+            "target_organ": "ORGAN-II",
+            "target_repo": "conversation-corpus--surfaces",
+            "consumes": ["STATE_MODEL", "VALIDATION_RECORD"],
+            "expected_output_signal": "INTERFACE_CONTRACT",
+            "readiness_command": (
+                "cce commercial h1 --project-root /path/to/project --write"
+            ),
         },
         "schemas": list_schemas(),
         "cli_surfaces": CLI_SURFACES,

--- a/src/conversation_corpus_engine/surface_exports.py
+++ b/src/conversation_corpus_engine/surface_exports.py
@@ -318,9 +318,7 @@ def build_surface_manifest(
             "target_repo": "conversation-corpus--surfaces",
             "consumes": ["STATE_MODEL", "VALIDATION_RECORD"],
             "expected_output_signal": "INTERFACE_CONTRACT",
-            "readiness_command": (
-                "cce commercial h1 --project-root /path/to/project --write"
-            ),
+            "readiness_command": ("cce commercial h1 --project-root /path/to/project --write"),
         },
         "schemas": list_schemas(),
         "cli_surfaces": CLI_SURFACES,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,6 +140,78 @@ def test_main_surface_bundle_prints_json_payload(
     assert payload["source_drop_root"] == str(tmp_path / "drop")
 
 
+def test_main_commercial_h1_writes_contract_and_prints_json(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_build_commercial_h1_readiness(
+        project_root: Path, source_drop_root: Path | None = None
+    ) -> dict[str, object]:
+        calls["build"] = (project_root, source_drop_root)
+        return {
+            "contract_name": "conversation-corpus-engine-commercial-h1-readiness-v1",
+            "summary": {"commercial_h1_repo_ready": True},
+        }
+
+    def fake_write_commercial_h1_artifacts(
+        project_root: Path, payload: dict[str, object]
+    ) -> dict[str, str]:
+        calls["write"] = (project_root, payload)
+        return {"json_path": str(project_root / "reports" / "commercial.json")}
+
+    monkeypatch.setattr(
+        MODULE,
+        "build_commercial_h1_readiness",
+        fake_build_commercial_h1_readiness,
+    )
+    monkeypatch.setattr(
+        MODULE,
+        "write_commercial_h1_artifacts",
+        fake_write_commercial_h1_artifacts,
+    )
+
+    _run_main(
+        monkeypatch,
+        [
+            "commercial",
+            "h1",
+            "--project-root",
+            str(tmp_path / "project"),
+            "--source-drop-root",
+            str(tmp_path / "drop"),
+            "--write",
+            "--json",
+        ],
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert calls["build"] == (tmp_path / "project", tmp_path / "drop")
+    assert calls["write"] == (
+        tmp_path / "project",
+        {
+            "contract_name": "conversation-corpus-engine-commercial-h1-readiness-v1",
+            "summary": {"commercial_h1_repo_ready": True},
+        },
+    )
+    assert payload["artifacts_written"]["json_path"].endswith("commercial.json")
+
+
+def test_main_mcp_serve_delegates_to_stdio_server(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_serve_mcp_stdio(*, project_root: Path) -> None:
+        calls["serve"] = project_root
+
+    monkeypatch.setattr(MODULE, "serve_mcp_stdio", fake_serve_mcp_stdio)
+
+    _run_main(monkeypatch, ["mcp", "serve", "--project-root", str(tmp_path)])
+
+    assert calls["serve"] == tmp_path
+
+
 def test_main_policy_replay_passes_threshold_overrides_and_writes_artifacts(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
 ) -> None:

--- a/tests/test_commercial_architecture.py
+++ b/tests/test_commercial_architecture.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from conversation_corpus_engine.commercial_architecture import (
+    build_commercial_h1_readiness,
+    commercial_h1_json_path,
+    write_commercial_h1_artifacts,
+)
+from conversation_corpus_engine.schema_validation import validate_json_file, validate_payload
+
+
+def test_commercial_h1_readiness_contract_tracks_repo_and_external_actions(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "project"
+    source_drop_root = tmp_path / "source-drop"
+
+    payload = build_commercial_h1_readiness(
+        project_root,
+        source_drop_root=source_drop_root,
+    )
+    validation = validate_payload("commercial-h1-readiness", payload)
+
+    assert validation["valid"], validation["errors"]
+    assert payload["summary"]["commercial_h1_repo_ready"] is True
+    assert payload["summary"]["repo_ready_action_count"] == 2
+    assert payload["summary"]["external_actions_remaining"] == 4
+    assert payload["package"]["readiness"]["mcp_distribution_ready"] is True
+    assert payload["interface_contract"]["target_repo"] == "conversation-corpus--surfaces"
+    assert payload["interface_contract"]["expected_output_signal"] == "INTERFACE_CONTRACT"
+
+
+def test_commercial_h1_artifacts_validate_against_schema(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    payload = build_commercial_h1_readiness(project_root)
+
+    artifacts = write_commercial_h1_artifacts(project_root, payload)
+    validation = validate_json_file("commercial-h1-readiness", commercial_h1_json_path(project_root))
+
+    assert validation["valid"], validation["errors"]
+    assert artifacts["json_path"].endswith("commercial-h1-readiness.json")
+    assert artifacts["markdown_path"].endswith("commercial-h1-readiness.md")

--- a/tests/test_commercial_architecture.py
+++ b/tests/test_commercial_architecture.py
@@ -36,7 +36,9 @@ def test_commercial_h1_artifacts_validate_against_schema(tmp_path: Path) -> None
     payload = build_commercial_h1_readiness(project_root)
 
     artifacts = write_commercial_h1_artifacts(project_root, payload)
-    validation = validate_json_file("commercial-h1-readiness", commercial_h1_json_path(project_root))
+    validation = validate_json_file(
+        "commercial-h1-readiness", commercial_h1_json_path(project_root)
+    )
 
     assert validation["valid"], validation["errors"]
     assert artifacts["json_path"].endswith("commercial-h1-readiness.json")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from conversation_corpus_engine.federation import build_federation, upsert_corpus
+from conversation_corpus_engine.import_markdown_document_corpus import (
+    import_markdown_document_corpus,
+)
+from conversation_corpus_engine.mcp_server import (
+    MCP_PROTOCOL_VERSION,
+    call_tool,
+    handle_jsonrpc_message,
+)
+
+
+def test_initialize_advertises_read_only_tool_capability() -> None:
+    response = handle_jsonrpc_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": MCP_PROTOCOL_VERSION},
+        }
+    )
+
+    assert response is not None
+    assert response["result"]["protocolVersion"] == MCP_PROTOCOL_VERSION
+    assert response["result"]["capabilities"] == {"tools": {"listChanged": False}}
+    assert response["result"]["serverInfo"]["name"] == "conversation-corpus-engine"
+
+
+def test_tools_list_exposes_corpus_search_tool() -> None:
+    response = handle_jsonrpc_message({"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+
+    assert response is not None
+    tools = response["result"]["tools"]
+    search_tool = next(item for item in tools if item["name"] == "cce_search")
+    assert search_tool["annotations"]["readOnlyHint"] is True
+    assert "query" in search_tool["inputSchema"]["required"]
+
+
+def test_cce_search_tool_returns_structured_answer_from_registered_corpus(
+    tmp_path: Path,
+) -> None:
+    project_root = tmp_path / "project"
+    source_root = tmp_path / "source"
+    corpus_root = tmp_path / "commercial-memory"
+    source_root.mkdir()
+    (source_root / "memory.md").write_text(
+        "# Commercial Memory\n\nSearch all AI conversations from one place and package the MCP server.\n",
+        encoding="utf-8",
+    )
+    import_markdown_document_corpus(
+        source_root,
+        corpus_root,
+        corpus_id="commercial-memory",
+        name="Commercial Memory",
+    )
+    upsert_corpus(
+        project_root,
+        corpus_root,
+        corpus_id="commercial-memory",
+        name="Commercial Memory",
+        make_default=True,
+    )
+    build_federation(project_root)
+
+    result = call_tool(
+        "cce_search",
+        {
+            "project_root": str(project_root),
+            "query": "commercial memory MCP server",
+            "limit": 4,
+        },
+    )
+
+    assert result["isError"] is False
+    assert result["content"][0]["type"] == "text"
+    assert result["structuredContent"]["query"] == "commercial memory MCP server"
+    assert (
+        result["structuredContent"]["federation"]["selected_corpus"]["corpus_id"]
+        == "commercial-memory"
+    )

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -43,6 +43,7 @@ class SchemaValidationTests(unittest.TestCase):
         self.assertEqual(
             names,
             [
+                "commercial-h1-readiness",
                 "corpus-candidate",
                 "corpus-contract",
                 "import-audit",


### PR DESCRIPTION
Autonomous **limen** dispatch of task `LIMEN-099`.

Audited 2026-06-01 from Jules-ready batch. IRF-CCE-033: Execute CCE commercial architecture — H1 actions

Refs: https://github.com/organvm-i-theoria/conversation-corpus-engine/issues/20

_Produced in an isolated worktree off origin — review before merge._

## Summary by Sourcery

Add MCP stdio server and commercial H1 readiness contract surfaces to CCE, wiring them into the CLI, surface manifest, schemas, packaging metadata, and tests.

New Features:
- Introduce a read-only MCP stdio server exposing corpus search, corpus listing, and provider readiness tools via JSON-RPC.
- Add a commercial H1 readiness contract generator that evaluates package/MCP distribution status and H1 commercial actions, and writes JSON/Markdown artifacts.
- Expose new `cce mcp serve` and `cce commercial h1` CLI commands and surface manifest entries for MCP and commercial readiness.

Enhancements:
- Extend surface exports to describe the commercial bridge from ORGAN-I to ORGAN-II and advertise the new MCP and commercial CLI surfaces.
- Enrich packaging metadata with readme, classifiers, keywords, an MCP extra, and a dedicated `cce-mcp` console script.
- Register and describe the new `commercial-h1-readiness` schema in the validation catalog.

Documentation:
- Update README to document the MCP server usage, commercial H1 readiness flow, new entry points, and repo ownership of the commercial bridge and artifacts.

Tests:
- Add tests for MCP server initialization, tool listing, and corpus search behavior.
- Add tests for the commercial H1 readiness contract payload, artifact writing, and schema validation.
- Extend CLI tests to cover the new `mcp serve` and `commercial h1` subcommands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Exposed MCP server with read-only tools for corpus search and readiness checks
  * Added commercial H1 readiness contract generation and reporting
  * New CLI commands for MCP server and commercial readiness operations

* **Documentation**
  * Updated README with MCP and commercial readiness information
  * Introduced schema validation for commercial contracts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->