### PR TITLE
[limen LIMEN-087] IRF-CCE-027: Post Office discover uses wrong API (gizmos != Projects)

### DIFF
--- a/playbooks/handoffs/gh-16-chatgpt-projects-endpoint.md
+++ b/playbooks/handoffs/gh-16-chatgpt-projects-endpoint.md
@@ -4,6 +4,22 @@
 **Archetype:** THE ACQUISITOR | **IRF:** IRF-CCE-027
 **Blocked by:** GH#15 (ChatGPT API scope degradation)
 
+> **Resolution (2026-06-18, LIMEN-087):** `discover_chatgpt_projects()` and
+> `fetch_chatgpt_project()` now target the ChatGPT **Projects** API
+> (`backend-api/projects` / `backend-api/projects/{id}`) via the
+> `PROJECTS_LIST_PATH` / `PROJECT_DETAIL_PATH` constants, not the gizmos
+> discovery API. Listing items are parsed by `_parse_project_item()` /
+> `_project_display_name()`, which read the flat Projects shape
+> (`id`/`name`/`files`) first and fall back to legacy gizmo-wrapped entries for
+> safety. Parsing + endpoint selection are covered by mocked unit tests in
+> `tests/test_chatgpt_local_session.py`.
+>
+> **Still open — live verification:** the exact JSON shapes could not be observed
+> from this environment (no valid session — see GH#15). When a session is
+> available, confirm the Projects list/detail paths and response shapes via
+> browser DevTools and adjust the two path constants + parsing helpers if they
+> differ. The registry/routing/status machinery needs no changes either way.
+
 ## Current State
 
 `discover_chatgpt_projects()` uses the **GPT Store discovery endpoint**, not the
@@ -59,10 +75,10 @@ API discovery endpoint is wrong.
 - [x] `fetch_chatgpt_project()` — project detail extraction (S38)
 - [x] `sync_chatgpt_projects()` — batch extraction orchestrator (S39)
 - [x] CLI: `cce project discover`, `cce project extract`, `cce project sync` (S39)
-- [ ] Identify correct Projects API endpoint
-- [ ] Update `discover_chatgpt_projects()` with correct endpoint
-- [ ] Update `fetch_chatgpt_project()` if detail endpoint also differs
-- [ ] Test end-to-end project discovery + extraction
+- [x] Identify correct Projects API endpoint (`backend-api/projects[/{id}]`; live-verify shapes)
+- [x] Update `discover_chatgpt_projects()` with correct endpoint + Projects-shape parsing
+- [x] Update `fetch_chatgpt_project()` to the Projects detail endpoint
+- [x] Unit tests for discovery endpoint + parsing (mocked); live end-to-end still pending GH#15
 - [ ] GH#16 closed
 
 ## Key Decisions

--- a/src/conversation_corpus_engine/chatgpt_local_session.py
+++ b/src/conversation_corpus_engine/chatgpt_local_session.py
@@ -652,10 +652,10 @@ def fetch_chatgpt_project(
     session = build_chatgpt_session(cookie_jar)
     output_root = output_root.resolve()
 
-    project = fetch_json(session, f"https://{CHATGPT_HOST}/backend-api/gizmos/{project_id}")
-    gizmo = project.get("gizmo") or {}
+    detail_path = PROJECT_DETAIL_PATH.format(project_id=project_id)
+    project = fetch_json(session, f"https://{CHATGPT_HOST}/{detail_path}")
     files = project.get("files") or []
-    project_name = gizmo.get("display", {}).get("name") or project_id
+    project_name = _project_display_name(project) or project_id
 
     meta_dir = output_root / "metadata"
     meta_dir.mkdir(parents=True, exist_ok=True)
@@ -771,6 +771,20 @@ def render_discovery_text(payload: dict[str, Any]) -> str:
 # Project registry (The Post Office)
 # ---------------------------------------------------------------------------
 
+# ChatGPT Projects API (distinct from the GPT Store "gizmos" API).
+#
+# ChatGPT Projects and custom GPTs ("gizmos") are separate features served by
+# different backend routes. The gizmos discovery API returns custom GPTs, NOT
+# Projects, so the Post Office must talk to the Projects API instead
+# (GH#16 / IRF-CCE-027). Project IDs are prefixed "g-p-" (gizmo-project).
+#
+# The JSON shapes parsed below follow the Projects API (flat ``id``/``name`` per
+# item), while staying tolerant of legacy gizmo-wrapped entries for safety. When
+# a valid ChatGPT session is available, live-verify these paths/shapes via
+# browser DevTools (see playbooks/handoffs/gh-16-chatgpt-projects-endpoint.md).
+PROJECTS_LIST_PATH = "backend-api/projects"
+PROJECT_DETAIL_PATH = "backend-api/projects/{project_id}"
+
 EXTRACTION_STATES = (
     "discovered",
     "queued",
@@ -861,19 +875,60 @@ def merge_project_discovery(
     return result
 
 
+def _project_display_name(item: dict[str, Any]) -> str:
+    """Extract a project's display name from a Projects-API or legacy gizmo entry."""
+    name = item.get("name") or item.get("title")
+    if name:
+        return name
+    gizmo = item.get("gizmo") or item.get("resource") or {}
+    display = gizmo.get("display") or {}
+    return display.get("name") or gizmo.get("name") or gizmo.get("title") or ""
+
+
+def _parse_project_item(item: dict[str, Any]) -> tuple[str, dict[str, Any]] | None:
+    """Normalize one Projects-API listing item to ``(project_id, info)``.
+
+    Reads the flat Projects shape (``id``/``name``) first and falls back to a
+    legacy gizmo-wrapped entry. Returns ``None`` when no project id is present.
+    """
+    pid = item.get("id") or ""
+    if not pid:
+        gizmo = item.get("gizmo") or item.get("resource") or {}
+        pid = gizmo.get("id") or ""
+    if not pid:
+        return None
+    interactions = (
+        item.get("num_conversations")
+        or item.get("conversation_count")
+        or (item.get("vanity_metrics") or {}).get("num_conversations")
+        or 0
+    )
+    info = {
+        "name": _project_display_name(item),
+        "interactions": interactions,
+        "file_count": len(item.get("files") or []),
+    }
+    return pid, info
+
+
 def discover_chatgpt_projects(
     cookie_jar: Path = DEFAULT_CHATGPT_COOKIE_JAR,
 ) -> dict[str, dict[str, Any]]:
-    """Fetch all ChatGPT project metadata from the API. Returns {project_id: info}."""
+    """Fetch all ChatGPT Project metadata from the Projects API.
+
+    Uses the ChatGPT Projects API (``backend-api/projects``), NOT the GPT Store
+    "gizmos" discovery API. Projects and custom GPTs are distinct ChatGPT
+    features served by different backend routes; the gizmos endpoint returns
+    custom GPTs, not Projects (GH#16 / IRF-CCE-027). Returns ``{project_id: info}``.
+    """
 
     session = build_chatgpt_session(cookie_jar)
-    # ChatGPT "gizmos" API returns projects as gizmo entries with resource_type "project"
     projects: dict[str, dict[str, Any]] = {}
     offset = 0
     limit = 100
     while True:
         url = (
-            f"https://{CHATGPT_HOST}/backend-api/projects?"
+            f"https://{CHATGPT_HOST}/{PROJECTS_LIST_PATH}?"
             f"{urlencode({'offset': offset, 'limit': limit})}"
         )
         try:
@@ -884,18 +939,10 @@ def discover_chatgpt_projects(
         if not items:
             break
         for item in items:
-            gizmo = item.get("gizmo") or item.get("resource") or item
-            gizmo_id = gizmo.get("id") or ""
-            display = gizmo.get("display") or {}
-            name = display.get("name") or gizmo.get("name") or gizmo.get("title") or ""
-            file_count = len(item.get("files") or [])
-            interaction_count = item.get("vanity_metrics", {}).get("num_conversations", 0)
-            if gizmo_id:
-                projects[gizmo_id] = {
-                    "name": name,
-                    "interactions": interaction_count,
-                    "file_count": file_count,
-                }
+            parsed = _parse_project_item(item)
+            if parsed is not None:
+                pid, info = parsed
+                projects[pid] = info
         if len(items) < limit:
             break
         offset += limit

--- a/tests/test_chatgpt_local_session.py
+++ b/tests/test_chatgpt_local_session.py
@@ -439,6 +439,105 @@ def test_merge_project_discovery_preserves_extraction_state() -> None:
     assert result["project_count"] == 2
 
 
+def _fake_project_session() -> module.ChatGPTHttpSession:
+    return module.ChatGPTHttpSession(
+        cookies=[],
+        session_payload={"account": {"id": "acct-1"}, "user": {"email": "u@example.com"}},
+        access_token="tok",  # allow-secret
+        account_id="acct-1",
+        device_id="dev-1",
+    )
+
+
+def test_project_display_name_prefers_flat_projects_shape() -> None:
+    assert module._project_display_name({"id": "g-p-a", "name": "My Project"}) == "My Project"
+    assert module._project_display_name({"title": "Titled"}) == "Titled"
+
+
+def test_project_display_name_falls_back_to_gizmo_wrapped() -> None:
+    item = {"gizmo": {"display": {"name": "Gizmo Display"}}}
+    assert module._project_display_name(item) == "Gizmo Display"
+    assert module._project_display_name({}) == ""
+
+
+def test_parse_project_item_reads_flat_projects_shape() -> None:
+    item = {
+        "id": "g-p-aaa",
+        "name": "Alpha",
+        "num_conversations": 7,
+        "files": [{"id": "f1"}, {"id": "f2"}],
+    }
+    parsed = module._parse_project_item(item)
+    assert parsed is not None
+    pid, info = parsed
+    assert pid == "g-p-aaa"
+    assert info == {"name": "Alpha", "interactions": 7, "file_count": 2}
+
+
+def test_parse_project_item_tolerates_legacy_gizmo_entry() -> None:
+    item = {
+        "gizmo": {"id": "g-p-bbb", "display": {"name": "Beta"}},
+        "vanity_metrics": {"num_conversations": 3},
+    }
+    parsed = module._parse_project_item(item)
+    assert parsed is not None
+    pid, info = parsed
+    assert pid == "g-p-bbb"
+    assert info["name"] == "Beta"
+    assert info["interactions"] == 3
+
+
+def test_parse_project_item_returns_none_without_id() -> None:
+    assert module._parse_project_item({"name": "no-id"}) is None
+
+
+def test_discover_chatgpt_projects_uses_projects_api(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    jar = tmp_path / "test.binarycookies"
+    jar.write_bytes(
+        build_binary_cookie_jar([{"domain": ".chatgpt.com", "name": "x", "value": "y"}])
+    )
+    monkeypatch.setattr(module, "build_chatgpt_session", lambda cookie_jar: _fake_project_session())
+    monkeypatch.setattr(module.time, "sleep", lambda _s: None)
+
+    seen_urls: list[str] = []
+
+    def fake_fetch_json(session: object, url: str) -> object:
+        seen_urls.append(url)
+        return {
+            "items": [
+                {"id": "g-p-aaa", "name": "Alpha", "num_conversations": 2},
+                {"id": "g-p-bbb", "name": "Beta", "files": [{"id": "f"}]},
+            ]
+        }
+
+    monkeypatch.setattr(module, "fetch_json", fake_fetch_json)
+
+    projects = module.discover_chatgpt_projects(jar)
+
+    # Hits the Projects API, NOT the gizmos discovery API.
+    assert seen_urls
+    assert "backend-api/projects?" in seen_urls[0]
+    assert all("gizmos" not in url for url in seen_urls)
+    assert projects["g-p-aaa"] == {"name": "Alpha", "interactions": 2, "file_count": 0}
+    assert projects["g-p-bbb"]["file_count"] == 1
+
+
+def test_discover_chatgpt_projects_stops_on_empty_page(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    jar = tmp_path / "test.binarycookies"
+    jar.write_bytes(
+        build_binary_cookie_jar([{"domain": ".chatgpt.com", "name": "x", "value": "y"}])
+    )
+    monkeypatch.setattr(module, "build_chatgpt_session", lambda cookie_jar: _fake_project_session())
+    monkeypatch.setattr(module.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(module, "fetch_json", lambda session, url: {"items": []})
+
+    assert module.discover_chatgpt_projects(jar) == {}
+
+
 def test_set_project_route_updates_registry(tmp_path: Path) -> None:
     registry = module.load_project_registry(tmp_path)
     registry["projects"]["g-p-aaa"] = module._blank_project_entry("g-p-aaa", "test", 5, 2)


### PR DESCRIPTION
Autonomous **limen** dispatch of task `LIMEN-087`.

Audited 2026-06-01 from Jules-ready batch. IRF-CCE-027: Post Office discover uses wrong API (gizmos != Projects)

Refs: https://github.com/organvm-i-theoria/conversation-corpus-engine/issues/16

_Produced in an isolated worktree off origin — review before merge._

## Summary by Sourcery

Switch ChatGPT project discovery and fetch logic from the gizmos API to the dedicated Projects API and align parsing with the Projects response shape.

Bug Fixes:
- Ensure project discovery uses the ChatGPT Projects endpoints instead of the gizmos discovery API, preventing incorrect item types from being registered.

Enhancements:
- Introduce reusable helpers and constants for Projects list/detail endpoints and project item parsing, including robust display-name extraction and backward compatibility with legacy gizmo-shaped entries.

Documentation:
- Update the ChatGPT Projects endpoint handoff playbook to record the new Projects API usage, parsing approach, and remaining live-verification steps.

Tests:
- Add unit tests covering project display-name resolution, project item parsing, Projects API endpoint selection, and pagination termination conditions for project discovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * ChatGPT projects are now fetched using the official Projects API for improved compatibility and reliability
* **Tests**
  * Added comprehensive test coverage for project discovery and parsing functionality
* **Documentation**
  * Updated project API migration documentation with completion status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->