### PR TITLE
[limen LIMEN-054] IRF-CCE-038: Cross-repo commercial awareness gap (CCE ↔ pipeline)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ It owns:
 
 It does not own raw intake routing or system-wide discovery contracts. Those belong in Meta integrations such as `alchemia-ingestvm`, `schema-definitions`, `organvm-engine`, and `organvm-mcp-server`.
 
+## Commercial Strategy Linkage
+
+CCE is the institutional memory and product-scale side of the ORGANVM income surface. Its commercial architecture is tracked in [`docs/superpowers/specs/2026-03-31-cce-commercial-architecture-design.md`](docs/superpowers/specs/2026-03-31-cce-commercial-architecture-design.md) and [`docs/superpowers/specs/2026-03-31-cce-commercial-architecture-expansion.md`](docs/superpowers/specs/2026-03-31-cce-commercial-architecture-expansion.md).
+
+The personal-capacity counterpart is [`4444J99/application-pipeline`](https://github.com/4444J99/application-pipeline), whose jobs, grants/residencies, and consulting tracks supply near-term income, market feedback, and enterprise-service leads for CCE Ring 4. This backlink closes `IRF-CCE-038` on the CCE side: the two repos should stay commercially aware of one another rather than treating pipeline revenue and CCE product revenue as separate strategies.
+
 ## Install
 
 ```bash

--- a/docs/superpowers/specs/2026-03-31-cce-commercial-architecture-design.md
+++ b/docs/superpowers/specs/2026-03-31-cce-commercial-architecture-design.md
@@ -4,6 +4,8 @@
 **Status:** APPROVED
 **Session:** S41
 **Scope:** Revenue architecture for conversation-corpus-engine and its position in the ORGANVM income surface
+**Cross-repo reference:** [`4444J99/application-pipeline`](https://github.com/4444J99/application-pipeline) is the personal-capacity income counterpart for jobs, grants/residencies, and consulting.
+**IRF:** IRF-CCE-038 DONE — CCE docs now backlink the pipeline revenue strategy.
 
 ---
 
@@ -208,6 +210,26 @@ income equation with different parameter weightings:
 - Pipeline Identity #9 (Founder/Operator) → IS the CCE commercial persona
 - Pipeline Identity #5 (Independent Engineer) → builds CCE engineering credibility
 - SGO research → papers on conversation federation = CCE marketing + omega #14
+
+### 8.1 Cross-Repo Commercial Awareness
+
+The canonical pipeline counterpart is
+[`4444J99/application-pipeline`](https://github.com/4444J99/application-pipeline).
+CCE owns the governed conversation corpus, provider federation, schemas, and
+surface exports that can become recurring product revenue. The pipeline owns the
+near-term application and relationship infrastructure that turns operator effort
+into jobs, grants/residencies, writing, and consulting income.
+
+Commercial planning must keep these docs linked in both directions:
+
+- CCE docs point to `application-pipeline` as the jobs/grants/consulting income
+  bridge that funds and validates CCE commercialization.
+- Pipeline docs should point back to this spec as the product-scale successor to
+  the same income surface, especially where consulting engagements become CCE
+  Ring 4 enterprise services.
+
+`IRF-CCE-038` is DONE for this repo: the CCE commercial architecture now carries
+an explicit pipeline backlink and names the shared revenue model.
 
 ### Revenue Evolution
 

--- a/docs/superpowers/specs/2026-03-31-cce-commercial-architecture-expansion.md
+++ b/docs/superpowers/specs/2026-03-31-cce-commercial-architecture-expansion.md
@@ -346,6 +346,13 @@ organism translation) remains correct. This expansion adds:
 
 The expansion incorporates the second tribunal's findings:
 
+**Pipeline backlink demand (IRF-CCE-038):** The expansion depends on
+[`4444J99/application-pipeline`](https://github.com/4444J99/application-pipeline)
+for the near-term cash-flow bridge. Pipeline jobs, grants/residencies, writing,
+and consulting are not separate from CCE commercialization; they are the
+personal-capacity side of the same income surface, while CCE product tiers are
+the institutional-scale side. Status: `IRF-CCE-038` DONE for this repo.
+
 **Stranger's demand (product brief):** The one-page brief becomes: "Your AI
 conversations become an institution." One sentence per loop, not per feature.
 


### PR DESCRIPTION
Autonomous **limen** dispatch of task `LIMEN-054`.

Audited 2026-06-01 from Jules-ready batch. Fix issue #23 in organvm-i-theoria/conversation-corpus-engine.

Refs: https://github.com/organvm-i-theoria/conversation-corpus-engine/issues/23, https://jules.google.com/session/13992835732913028712

_Produced in an isolated worktree off origin — review before merge._

## Summary by Sourcery

Document the commercial linkage between conversation-corpus-engine (CCE) and the separate application-pipeline repository, ensuring cross-repo awareness of the shared revenue model and marking IRF-CCE-038 as completed for this repo.

New Features:
- Add explicit cross-repo commercial awareness section to the CCE commercial architecture design spec, identifying application-pipeline as the personal-capacity income counterpart.
- Introduce a commercial strategy linkage section in the README that explains how CCE product revenue and pipeline income interact.

Documentation:
- Update commercial architecture design and expansion specs to reference the application-pipeline repo, describe their shared income surface, and record IRF-CCE-038 as DONE for CCE.