### PR TITLE
[limen CIFIX-organvm-i-theoria-conversation-corpus-engine] Fix pre-existing CI breakage (tsc/test-matrix errors) blocking all open PRs in organvm-i-theoria/conversation-corpus-engine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ Repository = "https://github.com/organvm-i-theoria/conversation-corpus-engine"
 Issues = "https://github.com/organvm-i-theoria/conversation-corpus-engine/issues"
 
 [project.optional-dependencies]
-dev = ["pytest>=9.0.3", "ruff>=0.4"]
+dev = ["pytest>=9.0.3", "ruff>=0.15.8,<0.16"]
 mcp = []
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.8,<0.16" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
Autonomous **limen** dispatch of task `CIFIX-organvm-i-theoria-conversation-corpus-engine`.

Fix the FAILING CI checks on the default branch of organvm-i-theoria/conversation-corpus-engine so its open PRs become mergeable. Failing checks: test, Analyze (CodeQL), schema-check. These are PRE-EXISTING breakage on the base branch (config/deps/types), NOT the PRs' code — fix the root cause minimally so each listed check goes green. Open ONE fix PR.

_Produced in an isolated worktree off origin — review before merge._