### PR TITLE
Pin CI dev tooling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,13 @@ Repository = "https://github.com/organvm-i-theoria/conversation-corpus-engine"
 Issues = "https://github.com/organvm-i-theoria/conversation-corpus-engine/issues"
 
 [project.optional-dependencies]
-dev = ["pytest>=9.0.3", "ruff>=0.15.8,<0.16", "mypy>=1.10.0"]
+# Pin CI-executed dev tooling to the known-good versions recorded in uv.lock. CI installs
+# via `pip install -e ".[dev]"` (which ignores the lockfile), so unpinned ranges
+# let pip pull whatever pytest/ruff is newest at run time. A newer ruff with
+# formatter or lint-rule changes silently breaks `ruff check` / `ruff format --check`
+# on every PR even though no source changed. Pinning keeps CI reproducible; bump
+# these deliberately.
+dev = ["pytest==9.0.3", "ruff==0.15.8", "mypy>=1.10.0"]
 mcp = []
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- pin CI-executed dev tooling to the versions already recorded in uv.lock
- preserve upstream mypy and mcp extras while making pytest/ruff installs deterministic

## Why
CI installs with `pip install -e ".[dev]"`, which ignores uv.lock. Leaving pytest/ruff as open ranges lets pip pull newer tooling than the lock records, so lint/format behavior can drift without source changes.

## Validation
- `python3 -m pip install -e ".[dev]"`
- `python3 -m pytest tests/ -v --tb=short`
- `python3 -m ruff check src/ tests/`
- `python3 -m ruff format --check src/ tests/`
- `python3 -c "from conversation_corpus_engine.schema_validation import list_schemas, load_schema; [load_schema(s['name']) for s in list_schemas()]"`
