### PR TITLE
fix: enforce corpus-store custody root

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ cce source freshness /path/to/corpus
 cce-mcp --project-root /path/to/project
 ```
 
-Corpus-destination writers fail closed unless a store has first been registered. The
+Corpus-destination writers fail closed unless a store has first been registered and the
+configured root exactly matches that active registration. The
 `--corpus-store-root` option takes precedence over `CCE_CORPUS_STORE_ROOT`; there is no
 implicit fallback. A store must already exist, must not traverse symlinks or contain nested
 Git repositories, and must either live outside Git or be wholly ignored and untracked.

--- a/README.md
+++ b/README.md
@@ -66,16 +66,17 @@ MIT
 ```bash
 cce corpus list --project-root /path/to/project
 cce corpus register /path/to/corpus --project-root /path/to/project --name "Notes Memory"
+cce corpus-store register --project-root /path/to/project --root /path/to/private-corpus-store
 cce federation build --project-root /path/to/project
 cce provider discover --project-root /path/to/project --source-drop-root /path/to/source-drop
-cce provider import --provider chatgpt --source-drop-root /path/to/source-drop --register --build
-cce provider import --provider gemini --source-drop-root /path/to/source-drop --register --build
-cce provider import --provider claude --mode local-session --local-root "/Users/you/Library/Application Support/Claude"
-cce provider bootstrap-eval --provider claude --project-root /path/to/project --full-eval
+cce provider import --provider chatgpt --project-root /path/to/project --corpus-store-root /path/to/private-corpus-store --source-drop-root /path/to/source-drop --register --build
+cce provider import --provider gemini --project-root /path/to/project --corpus-store-root /path/to/private-corpus-store --source-drop-root /path/to/source-drop --register --build
+cce provider import --provider claude --mode local-session --project-root /path/to/project --corpus-store-root /path/to/private-corpus-store --local-root "/Users/you/Library/Application Support/Claude"
+cce provider bootstrap-eval --provider claude --project-root /path/to/project --corpus-store-root /path/to/private-corpus-store --full-eval
 cce provider readiness --project-root /path/to/project --source-drop-root /path/to/source-drop --write
-cce provider refresh --provider chatgpt --project-root /path/to/project --source-drop-root /path/to/source-drop
-cce provider refresh --provider perplexity --project-root /path/to/project --source-drop-root /path/to/source-drop
-cce provider refresh --provider claude --project-root /path/to/project --promote --note "refresh and replace live corpus"
+cce provider refresh --provider chatgpt --project-root /path/to/project --corpus-store-root /path/to/private-corpus-store --source-drop-root /path/to/source-drop
+cce provider refresh --provider perplexity --project-root /path/to/project --corpus-store-root /path/to/private-corpus-store --source-drop-root /path/to/source-drop
+cce provider refresh --provider claude --project-root /path/to/project --corpus-store-root /path/to/private-corpus-store --promote --note "refresh and replace live corpus"
 cce schema list
 cce schema show corpus-contract
 cce schema validate corpus-contract --path /path/to/corpus/contract.json
@@ -90,12 +91,19 @@ cce candidate stage --project-root /path/to/project --candidate-root /path/to/ca
 cce candidate review --project-root /path/to/project --candidate-id latest --decision approve --note "promote candidate"
 cce candidate promote --project-root /path/to/project --candidate-id latest --note "replace live corpus"
 cce candidate rollback --project-root /path/to/project --target previous --note "restore previous live corpus"
-cce evaluation run --root /path/to/corpus --seed --json
+cce evaluation run --root /path/to/corpus --project-root /path/to/project --corpus-store-root /path/to/private-corpus-store --seed --json
 cce review queue --project-root /path/to/project
 cce review resolve federated-family-merge-... --decision accepted --note "same family"
 cce source freshness /path/to/corpus
 cce-mcp --project-root /path/to/project
 ```
+
+Corpus-destination writers fail closed unless a store has first been registered. The
+`--corpus-store-root` option takes precedence over `CCE_CORPUS_STORE_ROOT`; there is no
+implicit fallback. A store must already exist, must not traverse symlinks or contain nested
+Git repositories, and must either live outside Git or be wholly ignored and untracked.
+Provider imports default to `<store>/<corpus-id>`, while refresh candidates default to
+`<store>/provider-refresh/<provider>/<run-id>/candidate-corpus`.
 
 ## MCP Tools
 
@@ -113,6 +121,7 @@ currently exposes:
 - `src/conversation_corpus_engine/source_lifecycle.py` — source snapshot and freshness checks
 - `src/conversation_corpus_engine/federated_canon.py` — federated review state and canon builders
 - `src/conversation_corpus_engine/federation.py` — corpus registry and federation build/query logic
+- `src/conversation_corpus_engine/corpus_store.py` — private corpus-store registration and write authorization
 - `src/conversation_corpus_engine/import_markdown_document_corpus.py` — generic markdown corpus materialization
 - `src/conversation_corpus_engine/import_document_export_corpus.py` — document-style provider export import
 - `src/conversation_corpus_engine/import_claude_export_corpus.py` — Claude bundle import

--- a/docs/continuations/cce-corpus-store-root-20260723/workstream.json
+++ b/docs/continuations/cce-corpus-store-root-20260723/workstream.json
@@ -22,12 +22,12 @@
       "provider_and_model": "provider_neutral"
     },
     "runway": {
-      "deadline_at": null,
-      "deadline_epoch": null,
+      "deadline_at": "2026-07-24T13:14:04+00:00",
+      "deadline_epoch": 1784898844,
       "duration_seconds": 86400,
       "requested": "1d",
-      "started_at": null,
-      "started_epoch": null
+      "started_at": "2026-07-23T13:14:04+00:00",
+      "started_epoch": 1784812444
     },
     "schema": "limen.workstream.contract.v1"
   },

--- a/docs/continuations/cce-corpus-store-root-20260723/workstream.json
+++ b/docs/continuations/cce-corpus-store-root-20260723/workstream.json
@@ -1,0 +1,51 @@
+{
+  "branch": "work/cce-corpus-store-root-20260723",
+  "contract": {
+    "authorization": {
+      "approval_mode": "never",
+      "mode": "full_non_destructive",
+      "retained_gates": [
+        "destructive",
+        "credential",
+        "paid_spend",
+        "public_send",
+        "runtime_or_host_mutation"
+      ],
+      "reversible_in_scope": "proceed_without_confirmation",
+      "sandbox": "workspace-write"
+    },
+    "conductor": {
+      "boundary_rule": "recheck_remaining_runway_before_each_packet",
+      "expiry_rule": "stop_or_emit_successor_before_zero",
+      "lane_selection": "derive_from_live_capabilities",
+      "mode": "route_bounded_packets",
+      "provider_and_model": "provider_neutral"
+    },
+    "runway": {
+      "deadline_at": null,
+      "deadline_epoch": null,
+      "duration_seconds": 86400,
+      "requested": "1d",
+      "started_at": null,
+      "started_epoch": null
+    },
+    "schema": "limen.workstream.contract.v1"
+  },
+  "private_capsule": {
+    "content": "redacted",
+    "modules": [
+      "README.md",
+      "manifest.md",
+      "workstream.json",
+      "workstream-contract.py",
+      "intent.md",
+      "runtime.md",
+      "closeout.md",
+      "kickstart.sh",
+      "capsule.identity"
+    ]
+  },
+  "schema": "limen.workstream.receipt.v1",
+  "slug": "cce-corpus-store-root-20260723",
+  "workstream": "monolith-elimination"
+}

--- a/src/conversation_corpus_engine/cli.py
+++ b/src/conversation_corpus_engine/cli.py
@@ -22,6 +22,7 @@ from .corpus_candidates import (
     rollback_corpus_promotion,
     stage_corpus_candidate,
 )
+from .corpus_store import register_corpus_store
 from .dashboard import build_dashboard, render_dashboard_text
 from .evaluation import run_corpus_evaluation
 from .evaluation_bootstrap import bootstrap_provider_evaluation
@@ -140,6 +141,14 @@ def build_parser() -> argparse.ArgumentParser:
     corpus_register.add_argument("--name")
     corpus_register.add_argument("--default", action="store_true")
 
+    corpus_store = subparsers.add_parser("corpus-store", help="Manage private corpus custody")
+    corpus_store_sub = corpus_store.add_subparsers(dest="action", required=True)
+    corpus_store_register = corpus_store_sub.add_parser(
+        "register", help="Register the active private corpus-store root"
+    )
+    corpus_store_register.add_argument("--root", type=Path, required=True)
+    corpus_store_register.add_argument("--project-root", type=Path, default=default_project_root())
+
     corpus_extract = corpus_sub.add_parser("persona-extract", help="Extract persona lexicons")
     corpus_extract.add_argument("--persona", required=True, help="Persona ID (e.g. rob, claude)")
     corpus_extract.add_argument("--source-corpus", type=Path, help="Path to session transcripts")
@@ -207,6 +216,7 @@ def build_parser() -> argparse.ArgumentParser:
     provider_import.add_argument("--source-path", type=Path)
     provider_import.add_argument("--local-root", type=Path)
     provider_import.add_argument("--output-root", type=Path)
+    provider_import.add_argument("--corpus-store-root", type=Path)
     provider_import.add_argument("--corpus-id")
     provider_import.add_argument("--name")
     provider_import.add_argument("--register", action="store_true")
@@ -232,6 +242,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     provider_bootstrap.add_argument("--project-root", type=Path, default=default_project_root())
     provider_bootstrap.add_argument("--target-root", type=Path)
+    provider_bootstrap.add_argument("--corpus-store-root", type=Path)
     provider_bootstrap.add_argument("--policy-path", type=Path)
     provider_bootstrap.add_argument("--full-eval", action="store_true")
     provider_bootstrap.add_argument("--json", action="store_true")
@@ -259,6 +270,7 @@ def build_parser() -> argparse.ArgumentParser:
     provider_refresh.add_argument("--local-root", type=Path)
     provider_refresh.add_argument("--live-corpus-id")
     provider_refresh.add_argument("--candidate-root", type=Path)
+    provider_refresh.add_argument("--corpus-store-root", type=Path)
     provider_refresh.add_argument("--no-bootstrap-eval", action="store_true")
     provider_refresh.add_argument("--no-eval", action="store_true")
     provider_refresh.add_argument("--approve", action="store_true")
@@ -474,6 +486,8 @@ def build_parser() -> argparse.ArgumentParser:
     evaluation_sub = evaluation.add_subparsers(dest="action", required=True)
     evaluation_run = evaluation_sub.add_parser("run", help="Run evaluation for a corpus root")
     evaluation_run.add_argument("--root", type=Path, required=True)
+    evaluation_run.add_argument("--project-root", type=Path, default=default_project_root())
+    evaluation_run.add_argument("--corpus-store-root", type=Path)
     evaluation_run.add_argument("--seed", action="store_true")
     evaluation_run.add_argument("--markdown-output", type=Path)
     evaluation_run.add_argument("--json-output", type=Path)
@@ -749,6 +763,11 @@ def main() -> None:
         print(json.dumps(entry, indent=2))
         return
 
+    if args.group == "corpus-store" and args.action == "register":
+        registration = register_corpus_store(args.project_root, args.root)
+        print(json.dumps(registration, indent=2))
+        return
+
     if args.group == "federation" and args.action == "build":
         result = build_federation(args.project_root)
         print(json.dumps(result, indent=2))
@@ -809,6 +828,7 @@ def main() -> None:
             source_path=args.source_path,
             local_root=args.local_root,
             output_root=args.output_root,
+            corpus_store_root=args.corpus_store_root,
             corpus_id=args.corpus_id,
             name=args.name,
             register=args.register,
@@ -825,6 +845,7 @@ def main() -> None:
             target_root=args.target_root,
             policy_path=args.policy_path,
             full_eval=args.full_eval,
+            corpus_store_root=args.corpus_store_root,
         )
         print(json.dumps(payload, indent=2))
         return
@@ -839,6 +860,7 @@ def main() -> None:
             local_root=args.local_root,
             live_corpus_id=args.live_corpus_id,
             candidate_root=args.candidate_root,
+            corpus_store_root=args.corpus_store_root,
             bootstrap_eval=not args.no_bootstrap_eval,
             run_eval=not args.no_eval,
             approve=args.approve or args.promote,
@@ -1110,6 +1132,8 @@ def main() -> None:
             seed=args.seed,
             markdown_output=args.markdown_output,
             json_output=args.json_output,
+            project_root=args.project_root,
+            corpus_store_root=args.corpus_store_root,
         )
         payload = {
             "root": str(args.root.resolve()),

--- a/src/conversation_corpus_engine/corpus_store.py
+++ b/src/conversation_corpus_engine/corpus_store.py
@@ -6,7 +6,7 @@ import subprocess
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Mapping, Sequence
+from typing import Any, Mapping, Sequence
 
 from .federation import REGISTRY_VERSION, load_registry, now_iso, registry_path, save_registry
 
@@ -168,7 +168,7 @@ def resolve_configured_corpus_store_root(
     return _resolve_existing_store_root(configured)
 
 
-def load_corpus_store_registration(project_root: Path) -> dict[str, str]:
+def load_corpus_store_registry(project_root: Path) -> dict[str, Any]:
     path = registry_path(project_root.resolve())
     if not path.is_file():
         raise CorpusStoreError(f"Corpus-store registry does not exist: {path}")
@@ -190,6 +190,15 @@ def load_corpus_store_registration(project_root: Path) -> dict[str, str]:
     registered_root = registration.get("root")
     if not isinstance(registered_root, str) or not Path(registered_root).is_absolute():
         raise CorpusStoreError(f"Corpus-store registration has an invalid root in: {path}")
+    return registry
+
+
+def load_corpus_store_registration(project_root: Path) -> dict[str, str]:
+    registration = load_corpus_store_registry(project_root).get("corpus_store")
+    if not isinstance(registration, dict):
+        raise CorpusStoreError(
+            f"Corpus-store root is not registered in: {registry_path(project_root.resolve())}"
+        )
     return registration
 
 

--- a/src/conversation_corpus_engine/corpus_store.py
+++ b/src/conversation_corpus_engine/corpus_store.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from .federation import REGISTRY_VERSION, load_registry, now_iso, registry_path, save_registry
+
+CORPUS_STORE_ROOT_ENV = "CCE_CORPUS_STORE_ROOT"
+
+
+class CorpusStoreError(ValueError):
+    """Raised when a corpus write does not satisfy the private-custody contract."""
+
+
+@dataclass(frozen=True)
+class CorpusWriteAuthorization:
+    project_root: Path
+    store_root: Path
+    destination: Path
+
+
+def _absolute_path(path: Path) -> Path:
+    expanded = path.expanduser()
+    if not expanded.is_absolute():
+        expanded = Path.cwd() / expanded
+    return expanded.absolute()
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _run_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git_root(path: Path) -> Path | None:
+    result = _run_git(path, "rev-parse", "--show-toplevel")
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    if not value:
+        return None
+    return Path(value).resolve()
+
+
+def _git_path_is_ignored(git_root: Path, path: Path) -> bool:
+    try:
+        relative = path.relative_to(git_root)
+    except ValueError:
+        return False
+    result = _run_git(git_root, "check-ignore", "--quiet", "--", str(relative))
+    return result.returncode == 0
+
+
+def _find_nested_git_metadata(root: Path) -> Path | None:
+    for current_root, dirnames, filenames in os.walk(root, followlinks=False):
+        if ".git" in dirnames or ".git" in filenames:
+            return Path(current_root) / ".git"
+    return None
+
+
+def _find_symlink(root: Path) -> Path | None:
+    if root.is_symlink():
+        return root
+    if not root.exists():
+        return None
+    for current_root, dirnames, filenames in os.walk(root, followlinks=False):
+        current = Path(current_root)
+        for name in [*dirnames, *filenames]:
+            candidate = current / name
+            if candidate.is_symlink():
+                return candidate
+    return None
+
+
+def _validate_git_custody(root: Path) -> Path | None:
+    nested_git = _find_nested_git_metadata(root)
+    if nested_git is not None:
+        raise CorpusStoreError(
+            f"Corpus-store root contains nested Git metadata and is not private custody: {nested_git}"
+        )
+
+    git_root = _git_root(root)
+    if git_root is None:
+        return None
+
+    relative_root = root.relative_to(git_root)
+    tracked = _run_git(git_root, "ls-files", "-z", "--", str(relative_root))
+    if tracked.returncode != 0:
+        raise CorpusStoreError(
+            f"Could not inspect tracked content beneath corpus-store root: {root}"
+        )
+    if tracked.stdout:
+        raise CorpusStoreError(f"Corpus-store root contains Git-tracked content: {root}")
+
+    if not _git_path_is_ignored(git_root, root):
+        raise CorpusStoreError(f"Corpus-store root is Git-visible: {root}")
+    visible = _run_git(
+        git_root,
+        "ls-files",
+        "-z",
+        "--others",
+        "--exclude-standard",
+        "--",
+        str(relative_root),
+    )
+    if visible.returncode != 0:
+        raise CorpusStoreError(f"Could not inspect Git-visible corpus-store content: {root}")
+    if visible.stdout:
+        visible_path = visible.stdout.split("\0", 1)[0]
+        raise CorpusStoreError(
+            "Corpus-store root contains Git-visible content or an ignore-rule negation: "
+            f"{git_root / visible_path}"
+        )
+    return git_root
+
+
+def _resolve_existing_store_root(root: Path) -> Path:
+    lexical_root = _absolute_path(root)
+    if lexical_root.is_symlink():
+        raise CorpusStoreError(f"Corpus-store root may not be a symlink: {lexical_root}")
+    try:
+        resolved_root = lexical_root.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise CorpusStoreError(f"Corpus-store root does not exist: {lexical_root}") from exc
+    if not resolved_root.is_dir():
+        raise CorpusStoreError(f"Corpus-store root is not a directory: {resolved_root}")
+    return resolved_root
+
+
+def validate_corpus_store_root(root: Path) -> Path:
+    resolved_root = _resolve_existing_store_root(root)
+    _validate_git_custody(resolved_root)
+    return resolved_root
+
+
+def resolve_configured_corpus_store_root(
+    explicit_root: Path | None,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> Path:
+    environment = os.environ if environ is None else environ
+    configured = explicit_root
+    if configured is None:
+        raw_environment_root = environment.get(CORPUS_STORE_ROOT_ENV, "").strip()
+        if raw_environment_root:
+            configured = Path(raw_environment_root)
+    if configured is None:
+        raise CorpusStoreError(
+            "Corpus-store custody is not configured; provide --corpus-store-root or "
+            f"{CORPUS_STORE_ROOT_ENV}."
+        )
+    return _resolve_existing_store_root(configured)
+
+
+def load_corpus_store_registration(project_root: Path) -> dict[str, str]:
+    path = registry_path(project_root.resolve())
+    if not path.is_file():
+        raise CorpusStoreError(f"Corpus-store registry does not exist: {path}")
+    try:
+        registry = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CorpusStoreError(f"Corpus-store registry is malformed: {path}") from exc
+    if not isinstance(registry, dict):
+        raise CorpusStoreError(f"Corpus-store registry must be a JSON object: {path}")
+    if registry.get("registry_version") != REGISTRY_VERSION:
+        raise CorpusStoreError(f"Corpus-store registry must use version {REGISTRY_VERSION}: {path}")
+    if not isinstance(registry.get("corpora"), list):
+        raise CorpusStoreError(f"Corpus-store registry has malformed corpora state: {path}")
+    registration = registry.get("corpus_store")
+    if not isinstance(registration, dict):
+        raise CorpusStoreError(f"Corpus-store root is not registered in: {path}")
+    if registration.get("status") != "active":
+        raise CorpusStoreError(f"Corpus-store registration is not active in: {path}")
+    registered_root = registration.get("root")
+    if not isinstance(registered_root, str) or not Path(registered_root).is_absolute():
+        raise CorpusStoreError(f"Corpus-store registration has an invalid root in: {path}")
+    return registration
+
+
+def register_corpus_store(project_root: Path, root: Path) -> dict[str, str]:
+    resolved_project_root = _absolute_path(project_root)
+    if not resolved_project_root.is_dir():
+        raise CorpusStoreError(f"Project root does not exist: {resolved_project_root}")
+    resolved_root = validate_corpus_store_root(root)
+    registry = load_registry(resolved_project_root)
+    registration = registry.get("corpus_store")
+    if (
+        registry.get("registry_version") == REGISTRY_VERSION
+        and isinstance(registration, dict)
+        and registration.get("root") == str(resolved_root)
+        and registration.get("status") == "active"
+    ):
+        return deepcopy(registration)
+
+    new_registration = {
+        "root": str(resolved_root),
+        "status": "active",
+        "registered_at": now_iso(),
+    }
+    registry["corpus_store"] = new_registration
+    save_registry(resolved_project_root, registry)
+    return deepcopy(new_registration)
+
+
+def _reject_destination_symlinks(store_root: Path, lexical_destination: Path) -> None:
+    current = Path(lexical_destination.anchor)
+    for part in lexical_destination.parts[1:]:
+        current /= part
+        if not current.exists() and not current.is_symlink():
+            continue
+        if not current.is_symlink():
+            continue
+        resolved = current.resolve()
+        if (
+            _is_relative_to(current, store_root)
+            or resolved == store_root
+            or _is_relative_to(resolved, store_root)
+        ):
+            raise CorpusStoreError(
+                f"Corpus destination traverses a symlink beneath the registered store: {current}"
+            )
+
+
+def _validate_destination(
+    store_root: Path,
+    destination: Path,
+    *,
+    source_roots: Sequence[Path],
+    live_roots: Sequence[Path],
+) -> Path:
+    lexical_destination = _absolute_path(destination)
+    _reject_destination_symlinks(store_root, lexical_destination)
+    resolved_destination = lexical_destination.resolve(strict=False)
+    if resolved_destination == store_root or not _is_relative_to(resolved_destination, store_root):
+        raise CorpusStoreError(
+            "Corpus destination must be a strict descendant of the registered store: "
+            f"{resolved_destination}"
+        )
+
+    destination_symlink = _find_symlink(resolved_destination)
+    if destination_symlink is not None:
+        raise CorpusStoreError(
+            "Corpus destination contains a symlink beneath the registered store: "
+            f"{destination_symlink}"
+        )
+
+    for other in [*source_roots, *live_roots]:
+        resolved_other = _absolute_path(other).resolve(strict=False)
+        if (
+            resolved_destination == resolved_other
+            or _is_relative_to(resolved_destination, resolved_other)
+            or _is_relative_to(resolved_other, resolved_destination)
+        ):
+            raise CorpusStoreError(
+                "Corpus source/live root and destination overlap in either direction: "
+                f"{resolved_other} <-> {resolved_destination}"
+            )
+
+    git_root = _git_root(store_root)
+    if git_root is not None and not _git_path_is_ignored(git_root, resolved_destination):
+        raise CorpusStoreError(f"Corpus destination is Git-visible: {resolved_destination}")
+    return resolved_destination
+
+
+def authorize_corpus_write(
+    *,
+    project_root: Path,
+    destination: Path,
+    corpus_store_root: Path | None = None,
+    source_roots: Sequence[Path] = (),
+    live_roots: Sequence[Path] = (),
+) -> CorpusWriteAuthorization:
+    resolved_project_root = _absolute_path(project_root).resolve(strict=False)
+    configured_root = resolve_configured_corpus_store_root(corpus_store_root)
+    registration = load_corpus_store_registration(resolved_project_root)
+    registered_root = _resolve_existing_store_root(Path(registration["root"]))
+    if configured_root != registered_root:
+        raise CorpusStoreError(
+            "Configured corpus-store root does not match the active registration: "
+            f"{configured_root}"
+        )
+    validate_corpus_store_root(registered_root)
+    resolved_destination = _validate_destination(
+        registered_root,
+        destination,
+        source_roots=source_roots,
+        live_roots=live_roots,
+    )
+    return CorpusWriteAuthorization(
+        project_root=resolved_project_root,
+        store_root=registered_root,
+        destination=resolved_destination,
+    )
+
+
+def authorize_additional_corpus_path(
+    authorization: CorpusWriteAuthorization,
+    destination: Path,
+) -> CorpusWriteAuthorization:
+    return authorize_corpus_write(
+        project_root=authorization.project_root,
+        corpus_store_root=authorization.store_root,
+        destination=destination,
+    )

--- a/src/conversation_corpus_engine/evaluation.py
+++ b/src/conversation_corpus_engine/evaluation.py
@@ -15,6 +15,13 @@ from .answering import (
     write_json,
     write_markdown,
 )
+from .corpus_store import (
+    CorpusStoreError,
+    CorpusWriteAuthorization,
+    authorize_additional_corpus_path,
+    authorize_corpus_write,
+)
+from .paths import default_project_root
 
 DEFAULT_ROOT = Path.cwd()
 DETECTOR_KEYS = (
@@ -52,6 +59,8 @@ def parse_args() -> argparse.Namespace:
         description="Evaluate a conversation corpus against local gold fixtures."
     )
     parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    parser.add_argument("--project-root", type=Path, default=default_project_root())
+    parser.add_argument("--corpus-store-root", type=Path)
     parser.add_argument(
         "--seed",
         action="store_true",
@@ -821,8 +830,32 @@ def run_corpus_evaluation(
     seed: bool = False,
     markdown_output: Path | None = None,
     json_output: Path | None = None,
+    project_root: Path | None = None,
+    corpus_store_root: Path | None = None,
+    authorization: CorpusWriteAuthorization | None = None,
 ) -> tuple[dict[str, Any], dict[str, Path]]:
-    root = root.resolve()
+    requested_root = root
+    if authorization is None:
+        if project_root is None:
+            raise CorpusStoreError(
+                "Evaluation writes require project_root and registered corpus-store custody."
+            )
+        resolved_authorization = authorize_corpus_write(
+            project_root=project_root,
+            corpus_store_root=corpus_store_root,
+            destination=requested_root,
+        )
+    else:
+        resolved_authorization = authorize_corpus_write(
+            project_root=authorization.project_root,
+            corpus_store_root=authorization.store_root,
+            destination=requested_root,
+        )
+    root = resolved_authorization.destination
+    if markdown_output is not None:
+        authorize_additional_corpus_path(resolved_authorization, markdown_output)
+    if json_output is not None:
+        authorize_additional_corpus_path(resolved_authorization, json_output)
     if seed:
         seed_gold(root)
     scorecard = evaluate_current_corpus(root)
@@ -842,6 +875,8 @@ def main() -> int:
         seed=args.seed,
         markdown_output=args.markdown_output,
         json_output=args.json_output,
+        project_root=args.project_root,
+        corpus_store_root=args.corpus_store_root,
     )
 
     if args.json:

--- a/src/conversation_corpus_engine/evaluation_bootstrap.py
+++ b/src/conversation_corpus_engine/evaluation_bootstrap.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from .answering import load_json, write_markdown
+from .corpus_store import CorpusWriteAuthorization, authorize_corpus_write
 from .evaluation import run_corpus_evaluation, seed_gold
 from .paths import default_project_root
 from .provider_catalog import (
@@ -27,6 +28,7 @@ def parse_args() -> argparse.Namespace:
         description="Seed and scaffold manual evaluation for a provider corpus.",
     )
     parser.add_argument("--project-root", type=Path, default=DEFAULT_PROJECT_ROOT)
+    parser.add_argument("--corpus-store-root", type=Path)
     parser.add_argument("--provider", choices=["claude", "gemini", "grok", "perplexity", "copilot"])
     parser.add_argument("--target-root", type=Path)
     parser.add_argument("--policy-path", type=Path, default=DEFAULT_CLAUDE_POLICY_PATH)
@@ -47,7 +49,7 @@ def resolve_target_root(
     policy_path: Path | None = None,
 ) -> tuple[Path, dict[str, Any]]:
     if explicit_target_root is not None:
-        return explicit_target_root.resolve(), {
+        return explicit_target_root, {
             "provider": provider,
             "selection": "explicit",
             "policy_path": str(policy_path.resolve()) if policy_path else None,
@@ -58,6 +60,16 @@ def resolve_target_root(
         raise ValueError("Provide --provider or --target-root.")
 
     resolved_project_root = project_root.resolve()
+    if policy_path is not None and policy_path.is_file():
+        policy = load_json(policy_path, default={}) or {}
+        primary_root = policy.get("primary_root")
+        if primary_root:
+            return Path(primary_root), {
+                "provider": provider,
+                "selection": "primary",
+                "policy_path": str(policy_path.resolve()),
+                "policy": policy,
+            }
     source_drop_root = default_source_drop_root(resolved_project_root)
     targets = provider_corpus_targets(
         resolved_project_root, provider, source_drop_root, registry=[]
@@ -122,6 +134,8 @@ def bootstrap_provider_evaluation(
     target_root: Path | None = None,
     policy_path: Path | None = None,
     full_eval: bool = False,
+    corpus_store_root: Path | None = None,
+    authorization: CorpusWriteAuthorization | None = None,
 ) -> dict[str, Any]:
     resolved_project_root = project_root.resolve()
     resolved_target_root, resolution = resolve_target_root(
@@ -132,6 +146,14 @@ def bootstrap_provider_evaluation(
     )
     if not resolved_target_root.exists():
         raise FileNotFoundError(f"Target corpus root does not exist: {resolved_target_root}")
+    resolved_authorization = authorize_corpus_write(
+        project_root=resolved_project_root,
+        corpus_store_root=(
+            authorization.store_root if authorization is not None else corpus_store_root
+        ),
+        destination=resolved_target_root,
+    )
+    resolved_target_root = resolved_authorization.destination
 
     if provider is not None:
         provider_name = get_provider_config(provider)["display_name"]
@@ -146,7 +168,10 @@ def bootstrap_provider_evaluation(
     scorecard = None
     outputs: dict[str, str] = {}
     if full_eval:
-        scorecard, resolved_outputs = run_corpus_evaluation(resolved_target_root)
+        scorecard, resolved_outputs = run_corpus_evaluation(
+            resolved_target_root,
+            authorization=resolved_authorization,
+        )
         outputs = {key: str(value) for key, value in resolved_outputs.items()}
 
     metadata = corpus_metadata(resolved_target_root)
@@ -226,6 +251,7 @@ def bootstrap_claude_evaluation(
     policy_path: Path = DEFAULT_CLAUDE_POLICY_PATH,
     target_root: Path | None = None,
     full_eval: bool = False,
+    corpus_store_root: Path | None = None,
 ) -> dict[str, Any]:
     payload = bootstrap_provider_evaluation(
         project_root=project_root,
@@ -233,6 +259,7 @@ def bootstrap_claude_evaluation(
         target_root=target_root,
         policy_path=policy_path,
         full_eval=full_eval,
+        corpus_store_root=corpus_store_root,
     )
     return {
         "target_root": payload["target_root"],
@@ -256,6 +283,7 @@ def main() -> int:
         target_root=args.target_root,
         policy_path=args.policy_path,
         full_eval=args.full_eval,
+        corpus_store_root=args.corpus_store_root,
     )
     print(json.dumps(payload, indent=2))
     return 0

--- a/src/conversation_corpus_engine/evaluation_bootstrap.py
+++ b/src/conversation_corpus_engine/evaluation_bootstrap.py
@@ -8,7 +8,12 @@ from pathlib import Path
 from typing import Any
 
 from .answering import load_json, write_markdown
-from .corpus_store import CorpusWriteAuthorization, authorize_corpus_write
+from .corpus_store import (
+    CorpusWriteAuthorization,
+    authorize_corpus_write,
+    load_corpus_store_registry,
+    resolve_configured_corpus_store_root,
+)
 from .evaluation import run_corpus_evaluation, seed_gold
 from .paths import default_project_root
 from .provider_catalog import (
@@ -47,6 +52,7 @@ def resolve_target_root(
     provider: str | None,
     explicit_target_root: Path | None,
     policy_path: Path | None = None,
+    registry: list[dict[str, Any]] | None = None,
 ) -> tuple[Path, dict[str, Any]]:
     if explicit_target_root is not None:
         return explicit_target_root, {
@@ -72,7 +78,7 @@ def resolve_target_root(
             }
     source_drop_root = default_source_drop_root(resolved_project_root)
     targets = provider_corpus_targets(
-        resolved_project_root, provider, source_drop_root, registry=[]
+        resolved_project_root, provider, source_drop_root, registry=registry
     )
     target = next((item for item in targets if item.get("selected")), targets[0])
     return Path(target["root"]).resolve(), {
@@ -138,19 +144,26 @@ def bootstrap_provider_evaluation(
     authorization: CorpusWriteAuthorization | None = None,
 ) -> dict[str, Any]:
     resolved_project_root = project_root.resolve()
+    configured_store_root = (
+        authorization.store_root
+        if authorization is not None
+        else resolve_configured_corpus_store_root(corpus_store_root)
+    )
+    registry_entries = None
+    if target_root is None and provider is not None:
+        registry_entries = load_corpus_store_registry(resolved_project_root)["corpora"]
     resolved_target_root, resolution = resolve_target_root(
         project_root=resolved_project_root,
         provider=provider,
         explicit_target_root=target_root,
         policy_path=policy_path,
+        registry=registry_entries,
     )
     if not resolved_target_root.exists():
         raise FileNotFoundError(f"Target corpus root does not exist: {resolved_target_root}")
     resolved_authorization = authorize_corpus_write(
         project_root=resolved_project_root,
-        corpus_store_root=(
-            authorization.store_root if authorization is not None else corpus_store_root
-        ),
+        corpus_store_root=configured_store_root,
         destination=resolved_target_root,
     )
     resolved_target_root = resolved_authorization.destination

--- a/src/conversation_corpus_engine/evaluation_bootstrap.py
+++ b/src/conversation_corpus_engine/evaluation_bootstrap.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -106,31 +107,48 @@ def corpus_metadata(target_root: Path) -> dict[str, Any]:
 
 def render_manual_guide(
     *,
-    provider_slug: str,
+    provider_slug: str | None,
     provider_name: str,
     target_root: Path,
+    project_root: Path,
+    corpus_store_root: Path,
     full_eval: bool,
 ) -> str:
-    rerun_command = f"cce evaluation run --root {target_root}"
-    refresh_command = f"cce provider bootstrap-eval --provider {provider_slug} --target-root {target_root} --full-eval"
-    return "\n".join(
-        [
-            f"# {provider_name} Manual Evaluation Guide",
-            "",
-            f"- Generated: {datetime.now(timezone.utc).isoformat()}",
-            f"- Target root: {target_root}",
-            f"- Full eval ran during bootstrap: {'yes' if full_eval else 'no'}",
-            "",
-            "## Next Manual Steps",
-            "",
-            "- Review `eval/gold/manual/detectors.json` and confirm or reject seeded detector truth.",
-            "- Review `eval/gold/manual/families.json` and confirm canonical family membership.",
-            "- Review `eval/fixtures/manual/retrieval.json` and replace seeded retrieval prompts with provider-specific cases.",
-            "- Review `eval/gold/manual/answers.json` and replace seeded answer fixtures with grounded expectations.",
-            f"- Re-run `{rerun_command}` after manual edits.",
-            f"- Use `{refresh_command}` only when you want the seeded baseline refreshed and re-scored.",
-        ],
+    quoted_target_root = shlex.quote(str(target_root))
+    quoted_project_root = shlex.quote(str(project_root))
+    quoted_store_root = shlex.quote(str(corpus_store_root))
+    rerun_command = (
+        f"cce evaluation run --root {quoted_target_root} "
+        f"--project-root {quoted_project_root} "
+        f"--corpus-store-root {quoted_store_root}"
     )
+    lines = [
+        f"# {provider_name} Manual Evaluation Guide",
+        "",
+        f"- Generated: {datetime.now(timezone.utc).isoformat()}",
+        f"- Target root: {target_root}",
+        f"- Full eval ran during bootstrap: {'yes' if full_eval else 'no'}",
+        "",
+        "## Next Manual Steps",
+        "",
+        "- Review `eval/gold/manual/detectors.json` and confirm or reject seeded detector truth.",
+        "- Review `eval/gold/manual/families.json` and confirm canonical family membership.",
+        "- Review `eval/fixtures/manual/retrieval.json` and replace seeded retrieval prompts with provider-specific cases.",
+        "- Review `eval/gold/manual/answers.json` and replace seeded answer fixtures with grounded expectations.",
+        f"- Re-run `{rerun_command}` after manual edits.",
+    ]
+    if provider_slug is not None:
+        refresh_command = (
+            "cce provider bootstrap-eval "
+            f"--provider {shlex.quote(provider_slug)} "
+            f"--project-root {quoted_project_root} "
+            f"--target-root {quoted_target_root} "
+            f"--corpus-store-root {quoted_store_root} --full-eval"
+        )
+        lines.append(
+            f"- Use `{refresh_command}` only when you want the seeded baseline refreshed and re-scored."
+        )
+    return "\n".join(lines)
 
 
 def bootstrap_provider_evaluation(
@@ -192,9 +210,11 @@ def bootstrap_provider_evaluation(
     write_markdown(
         guidance_path,
         render_manual_guide(
-            provider_slug=provider or "external",
+            provider_slug=provider,
             provider_name=provider_name,
             target_root=resolved_target_root,
+            project_root=resolved_project_root,
+            corpus_store_root=resolved_authorization.store_root,
             full_eval=full_eval,
         ),
     )

--- a/src/conversation_corpus_engine/federation.py
+++ b/src/conversation_corpus_engine/federation.py
@@ -25,7 +25,7 @@ from .source_lifecycle import compute_source_freshness
 
 DEFAULT_PROJECT_ROOT = default_project_root()
 FEDERATION_CONTRACT = "conversation-corpus-engine-v1"
-REGISTRY_VERSION = 1
+REGISTRY_VERSION = 2
 REQUIRED_CONTRACT_FILES = (
     "corpus/threads-index.json",
     "corpus/semantic-v3-index.json",
@@ -111,6 +111,7 @@ def load_registry(project_root: Path) -> dict[str, Any]:
 
 
 def save_registry(project_root: Path, registry: dict[str, Any]) -> dict[str, Any]:
+    registry["registry_version"] = REGISTRY_VERSION
     registry["generated_at"] = now_iso()
     active = [
         entry for entry in registry.get("corpora", []) if entry.get("status", "active") == "active"

--- a/src/conversation_corpus_engine/provider_import.py
+++ b/src/conversation_corpus_engine/provider_import.py
@@ -5,6 +5,11 @@ from typing import Any
 
 from .chatgpt_local_session import DEFAULT_CHATGPT_COOKIE_JAR
 from .claude_local_session import DEFAULT_CLAUDE_LOCAL_ROOT
+from .corpus_store import (
+    CorpusWriteAuthorization,
+    authorize_corpus_write,
+    resolve_configured_corpus_store_root,
+)
 from .evaluation_bootstrap import bootstrap_provider_evaluation
 from .federation import build_federation, upsert_corpus
 from .import_chatgpt_export_corpus import import_chatgpt_export_corpus
@@ -13,7 +18,6 @@ from .import_claude_export_corpus import import_claude_export_corpus
 from .import_claude_local_session_corpus import import_claude_local_session_corpus
 from .import_document_export_corpus import import_document_export_corpus
 from .provider_catalog import (
-    conventional_corpus_root,
     default_source_drop_root,
     get_provider_config,
 )
@@ -30,12 +34,14 @@ def bootstrap_manual_review(
     *,
     project_root: Path,
     full_eval: bool = False,
+    authorization: CorpusWriteAuthorization,
 ) -> dict[str, Any]:
     return bootstrap_provider_evaluation(
         project_root=project_root,
         provider=provider_slug,
         target_root=target_root,
         full_eval=full_eval,
+        authorization=authorization,
     )
 
 
@@ -81,22 +87,10 @@ def resolve_provider_import_source(
 
 def default_output_root(
     *,
-    provider: str,
-    mode: str,
-    project_root: Path,
-    source_drop_root: Path | None,
+    corpus_store_root: Path,
+    corpus_id: str,
 ) -> Path:
-    config = get_provider_config(provider)
-    if mode == "local-session" and provider in {"claude", "chatgpt"}:
-        corpus_id = config["default_corpus_id"]
-    else:
-        corpus_id = (
-            config["default_corpus_id"] if provider != "claude" else config["fallback_corpus_id"]
-        )
-    resolved_source_drop_root = (
-        source_drop_root or default_source_drop_root(project_root)
-    ).resolve()
-    return conventional_corpus_root(resolved_source_drop_root, corpus_id)
+    return corpus_store_root / corpus_id
 
 
 def import_provider_corpus(
@@ -108,6 +102,7 @@ def import_provider_corpus(
     source_path: Path | None = None,
     local_root: Path | None = None,
     output_root: Path | None = None,
+    corpus_store_root: Path | None = None,
     corpus_id: str | None = None,
     name: str | None = None,
     register: bool = False,
@@ -116,6 +111,13 @@ def import_provider_corpus(
     throttle: float = 0.0,
 ) -> dict[str, Any]:
     config = get_provider_config(provider)
+    if provider == "claude" and mode != "local-session":
+        resolved_corpus_id = corpus_id or config["fallback_corpus_id"]
+        resolved_name = name or config["fallback_corpus_name"]
+    else:
+        resolved_corpus_id = corpus_id or config["default_corpus_id"]
+        resolved_name = name or config["default_corpus_name"]
+
     resolved_source_path, resolution = resolve_provider_import_source(
         provider=provider,
         mode=mode,
@@ -124,21 +126,20 @@ def import_provider_corpus(
         source_path=source_path,
         local_root=local_root,
     )
-    resolved_output_root = (
-        output_root
-        or default_output_root(
-            provider=provider,
-            mode=mode,
-            project_root=project_root,
-            source_drop_root=source_drop_root,
-        )
-    ).resolve()
-    resolved_corpus_id = corpus_id
-    resolved_name = name
+    configured_store_root = resolve_configured_corpus_store_root(corpus_store_root)
+    requested_output_root = output_root or default_output_root(
+        corpus_store_root=configured_store_root,
+        corpus_id=resolved_corpus_id,
+    )
+    authorization = authorize_corpus_write(
+        project_root=project_root,
+        corpus_store_root=configured_store_root,
+        destination=requested_output_root,
+        source_roots=(resolved_source_path,),
+    )
+    resolved_output_root = authorization.destination
 
     if provider == "claude" and mode == "local-session":
-        resolved_corpus_id = resolved_corpus_id or config["default_corpus_id"]
-        resolved_name = resolved_name or config["default_corpus_name"]
         import_result = import_claude_local_session_corpus(
             resolved_source_path,
             resolved_output_root,
@@ -147,8 +148,6 @@ def import_provider_corpus(
             throttle=throttle,
         )
     elif provider == "chatgpt" and mode == "local-session":
-        resolved_corpus_id = resolved_corpus_id or config["default_corpus_id"]
-        resolved_name = resolved_name or config["default_corpus_name"]
         import_result = import_chatgpt_local_session_corpus(
             resolved_source_path,
             resolved_output_root,
@@ -157,8 +156,6 @@ def import_provider_corpus(
             throttle=throttle,
         )
     elif provider == "chatgpt":
-        resolved_corpus_id = resolved_corpus_id or config["default_corpus_id"]
-        resolved_name = resolved_name or config["default_corpus_name"]
         import_result = import_chatgpt_export_corpus(
             resolved_source_path,
             resolved_output_root,
@@ -167,8 +164,6 @@ def import_provider_corpus(
             throttle=throttle,
         )
     elif provider == "claude":
-        resolved_corpus_id = resolved_corpus_id or config["fallback_corpus_id"]
-        resolved_name = resolved_name or config["fallback_corpus_name"]
         import_result = import_claude_export_corpus(
             resolved_source_path,
             resolved_output_root,
@@ -177,8 +172,6 @@ def import_provider_corpus(
             throttle=throttle,
         )
     else:
-        resolved_corpus_id = resolved_corpus_id or config["default_corpus_id"]
-        resolved_name = resolved_name or config["default_corpus_name"]
         import_result = import_document_export_corpus(
             resolved_source_path,
             resolved_output_root,
@@ -194,6 +187,7 @@ def import_provider_corpus(
             resolved_output_root,
             project_root=project_root.resolve(),
             full_eval=False,
+            authorization=authorization,
         )
         if bootstrap_eval
         else None

--- a/src/conversation_corpus_engine/provider_readiness.py
+++ b/src/conversation_corpus_engine/provider_readiness.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from .answering import write_json, write_markdown
-from .federation import list_registered_corpora, load_corpus_surface
+from .federation import load_corpus_surface, load_registry
 from .provider_catalog import PROVIDER_CONFIG, get_provider_config, provider_corpus_targets
 from .provider_discovery import discover_provider_uploads
 
@@ -82,38 +82,72 @@ def target_register_command(target: dict[str, Any]) -> str:
     )
 
 
+def corpus_store_register_command(project_root: Path) -> str:
+    return (
+        "cce corpus-store register "
+        f"--project-root {shlex.quote(str(project_root.resolve()))} "
+        "--root /path/to/private-corpus-store"
+    )
+
+
+def corpus_writer_command(
+    command: str,
+    *,
+    project_root: Path,
+    corpus_store_root: Path | None,
+) -> str:
+    if corpus_store_root is None:
+        return corpus_store_register_command(project_root)
+    return f"{command} --corpus-store-root {shlex.quote(str(corpus_store_root.resolve()))}"
+
+
 def determine_next_command(
     provider: str,
     discovery: dict[str, Any],
     selected_target: dict[str, Any],
     *,
     project_root: Path,
+    corpus_store_root: Path | None,
 ) -> str:
     config = get_provider_config(provider)
     state = target_readiness_state(selected_target)
     source_drop_root = discovery["inbox_root"].rsplit(f"/{provider}/inbox", 1)[0]
     if state == "missing":
         if discovery.get("upload_state") == "ready":
-            return (
-                f"cce provider import --provider {provider} --source-drop-root {source_drop_root} "
-                "--register --build"
+            return corpus_writer_command(
+                f"cce provider import --provider {provider} "
+                f"--project-root {shlex.quote(str(project_root.resolve()))} "
+                f"--source-drop-root {shlex.quote(source_drop_root)} --register --build",
+                project_root=project_root,
+                corpus_store_root=corpus_store_root,
             )
         return f"Place a supported {config['display_name']} export in {discovery['inbox_root']}"
     if state == "missing-contract":
         return f"Create corpus contract and index files under {selected_target['root']}/corpus"
     if state == "imported-needs-bootstrap":
-        return (
+        return corpus_writer_command(
             f"cce provider bootstrap-eval --provider {provider} "
-            f"--project-root {project_root.resolve()} --target-root {selected_target['root']}"
+            f"--project-root {shlex.quote(str(project_root.resolve()))} "
+            f"--target-root {shlex.quote(selected_target['root'])}",
+            project_root=project_root,
+            corpus_store_root=corpus_store_root,
         )
     if state in {"manual-eval-pending", "manual-eval-unrun"}:
-        return f"Update manual fixtures under {selected_target['root']}/eval and run cce evaluation run --root {selected_target['root']}"
+        return corpus_writer_command(
+            f"cce evaluation run --root {shlex.quote(selected_target['root'])} "
+            f"--project-root {shlex.quote(str(project_root.resolve()))}",
+            project_root=project_root,
+            corpus_store_root=corpus_store_root,
+        )
     if state == "calibration-pass":
         return target_register_command(selected_target)
     if state == "healthy-federation" and discovery.get("upload_state") == "ready":
-        return (
+        return corpus_writer_command(
             f"cce provider refresh --provider {provider} "
-            f"--project-root {project_root.resolve()} --source-drop-root {source_drop_root}"
+            f"--project-root {shlex.quote(str(project_root.resolve()))} "
+            f"--source-drop-root {shlex.quote(source_drop_root)}",
+            project_root=project_root,
+            corpus_store_root=corpus_store_root,
         )
     return "ready"
 
@@ -125,6 +159,7 @@ def summarize_provider_readiness(
     registry_by_root: dict[str, dict[str, Any]],
     project_root: Path,
     source_drop_root: Path,
+    corpus_store_root: Path | None,
 ) -> dict[str, Any]:
     config = get_provider_config(provider)
     registry = list(registry_by_corpus_id.values())
@@ -155,6 +190,7 @@ def summarize_provider_readiness(
             discovery,
             selected_target,
             project_root=project_root,
+            corpus_store_root=corpus_store_root,
         ),
         "notes": config.get("notes", []),
         "policy": {
@@ -172,9 +208,18 @@ def build_provider_readiness(project_root: Path, source_drop_root: Path) -> dict
     source_drop_root = source_drop_root.resolve()
     discovery_payload = discover_provider_uploads(project_root, source_drop_root)
     discovery_by_provider = {item["provider"]: item for item in discovery_payload["providers"]}
-    registry = list_registered_corpora(project_root)
+    registry_payload = load_registry(project_root)
+    registry = registry_payload.get("corpora") or []
     registry_by_corpus_id = {item["corpus_id"]: item for item in registry}
     registry_by_root = {str(Path(item["root"]).resolve()): item for item in registry}
+    store_registration = registry_payload.get("corpus_store")
+    corpus_store_root = (
+        Path(store_registration["root"])
+        if isinstance(store_registration, dict)
+        and store_registration.get("status") == "active"
+        and isinstance(store_registration.get("root"), str)
+        else None
+    )
     providers = [
         summarize_provider_readiness(
             provider,
@@ -183,6 +228,7 @@ def build_provider_readiness(project_root: Path, source_drop_root: Path) -> dict
             registry_by_root,
             project_root,
             source_drop_root,
+            corpus_store_root,
         )
         for provider in PROVIDER_CONFIG
     ]

--- a/src/conversation_corpus_engine/provider_readiness.py
+++ b/src/conversation_corpus_engine/provider_readiness.py
@@ -101,6 +101,23 @@ def corpus_writer_command(
     return f"{command} --corpus-store-root {shlex.quote(str(corpus_store_root.resolve()))}"
 
 
+def target_is_store_backed(target: dict[str, Any], corpus_store_root: Path | None) -> bool:
+    if corpus_store_root is None:
+        return False
+    return Path(target["root"]).resolve().is_relative_to(corpus_store_root.resolve())
+
+
+def legacy_target_guidance(
+    target: dict[str, Any],
+    corpus_store_root: Path,
+) -> str:
+    destination = corpus_store_root.resolve() / target["corpus_id"]
+    return (
+        f"Migrate or re-import {target['corpus_id']} into the active corpus store "
+        f"at {destination} before writing evaluation assets."
+    )
+
+
 def determine_next_command(
     provider: str,
     discovery: dict[str, Any],
@@ -122,6 +139,18 @@ def determine_next_command(
                 corpus_store_root=corpus_store_root,
             )
         return f"Place a supported {config['display_name']} export in {discovery['inbox_root']}"
+    if (
+        state
+        in {
+            "missing-contract",
+            "imported-needs-bootstrap",
+            "manual-eval-pending",
+            "manual-eval-unrun",
+        }
+        and corpus_store_root is not None
+        and not target_is_store_backed(selected_target, corpus_store_root)
+    ):
+        return legacy_target_guidance(selected_target, corpus_store_root)
     if state == "missing-contract":
         return f"Create corpus contract and index files under {selected_target['root']}/corpus"
     if state == "imported-needs-bootstrap":

--- a/src/conversation_corpus_engine/provider_refresh.py
+++ b/src/conversation_corpus_engine/provider_refresh.py
@@ -12,6 +12,11 @@ from .corpus_candidates import (
     review_corpus_candidate,
     stage_corpus_candidate,
 )
+from .corpus_store import (
+    authorize_additional_corpus_path,
+    authorize_corpus_write,
+    resolve_configured_corpus_store_root,
+)
 from .evaluation import run_corpus_evaluation
 from .provider_catalog import get_provider_config
 from .provider_import import import_provider_corpus
@@ -71,8 +76,8 @@ def infer_refresh_mode(
     return "upload", "live-corpus-id"
 
 
-def default_refresh_candidate_root(project_root: Path, provider: str, run_id: str) -> Path:
-    return provider_refresh_runs_dir(project_root) / provider / run_id / "candidate-corpus"
+def default_refresh_candidate_root(corpus_store_root: Path, provider: str, run_id: str) -> Path:
+    return corpus_store_root / "provider-refresh" / provider / run_id / "candidate-corpus"
 
 
 def render_provider_refresh(payload: dict[str, Any]) -> str:
@@ -108,6 +113,7 @@ def refresh_provider_corpus(
     local_root: Path | None = None,
     live_corpus_id: str | None = None,
     candidate_root: Path | None = None,
+    corpus_store_root: Path | None = None,
     bootstrap_eval: bool = True,
     run_eval: bool = True,
     approve: bool = False,
@@ -116,6 +122,19 @@ def refresh_provider_corpus(
     throttle: float = 0.0,
 ) -> dict[str, Any]:
     resolved_project_root = project_root.resolve()
+    configured_store_root = resolve_configured_corpus_store_root(corpus_store_root)
+    run_id = f"{provider}-{timestamp_slug()}"
+    requested_candidate_root = candidate_root or default_refresh_candidate_root(
+        configured_store_root,
+        provider,
+        run_id,
+    )
+    preliminary_authorization = authorize_corpus_write(
+        project_root=resolved_project_root,
+        corpus_store_root=configured_store_root,
+        destination=requested_candidate_root,
+    )
+    resolved_candidate_root = preliminary_authorization.destination
     live_entry = resolve_live_entry(
         resolved_project_root,
         live_corpus_id=live_corpus_id,
@@ -126,15 +145,14 @@ def refresh_provider_corpus(
         live_corpus_id=live_entry["corpus_id"],
         mode=mode,
     )
-    run_id = f"{provider}-{timestamp_slug()}"
-    resolved_candidate_root = (
-        candidate_root
-        or default_refresh_candidate_root(
-            resolved_project_root,
-            provider,
-            run_id,
-        )
-    ).resolve()
+    authorization = authorize_corpus_write(
+        project_root=resolved_project_root,
+        corpus_store_root=preliminary_authorization.store_root,
+        destination=resolved_candidate_root,
+        live_roots=(Path(live_entry["root"]),),
+    )
+    refresh_root = resolved_candidate_root.parent
+    authorize_additional_corpus_path(authorization, refresh_root)
 
     import_result = import_provider_corpus(
         project_root=resolved_project_root,
@@ -144,6 +162,7 @@ def refresh_provider_corpus(
         source_path=source_path,
         local_root=local_root,
         output_root=resolved_candidate_root,
+        corpus_store_root=authorization.store_root,
         corpus_id=live_entry["corpus_id"],
         name=live_entry["name"],
         register=False,
@@ -155,7 +174,11 @@ def refresh_provider_corpus(
     scorecard = None
     evaluation_outputs: dict[str, str] = {}
     if run_eval:
-        scorecard, outputs = run_corpus_evaluation(resolved_candidate_root, seed=True)
+        scorecard, outputs = run_corpus_evaluation(
+            resolved_candidate_root,
+            seed=True,
+            authorization=authorization,
+        )
         evaluation_outputs = {key: str(value) for key, value in outputs.items()}
 
     candidate_manifest = stage_corpus_candidate(
@@ -186,7 +209,6 @@ def refresh_provider_corpus(
         resolved_project_root,
         candidate_id=candidate_manifest["candidate_id"],
     )
-    refresh_root = resolved_candidate_root.parent
     payload = {
         "run_id": run_id,
         "generated_at": now_iso(),

--- a/src/conversation_corpus_engine/provider_refresh.py
+++ b/src/conversation_corpus_engine/provider_refresh.py
@@ -80,6 +80,10 @@ def default_refresh_candidate_root(corpus_store_root: Path, provider: str, run_i
     return corpus_store_root / "provider-refresh" / provider / run_id / "candidate-corpus"
 
 
+def default_refresh_receipt_root(corpus_store_root: Path, provider: str, run_id: str) -> Path:
+    return corpus_store_root / "provider-refresh" / provider / run_id
+
+
 def render_provider_refresh(payload: dict[str, Any]) -> str:
     evaluation = payload.get("evaluation") or {}
     candidate = payload.get("candidate") or {}
@@ -151,8 +155,15 @@ def refresh_provider_corpus(
         destination=resolved_candidate_root,
         live_roots=(Path(live_entry["root"]),),
     )
-    refresh_root = resolved_candidate_root.parent
-    authorize_additional_corpus_path(authorization, refresh_root)
+    refresh_root = default_refresh_receipt_root(authorization.store_root, provider, run_id)
+    resolved_refresh_root = authorize_additional_corpus_path(
+        authorization,
+        refresh_root,
+    ).destination
+    if resolved_refresh_root == resolved_candidate_root or resolved_refresh_root.is_relative_to(
+        resolved_candidate_root
+    ):
+        raise ValueError("Refresh receipts must be written outside the candidate corpus.")
 
     import_result = import_provider_corpus(
         project_root=resolved_project_root,
@@ -231,9 +242,11 @@ def refresh_provider_corpus(
         "candidate": latest_candidate_manifest,
         "review": review_result,
         "promotion": promotion_result,
+        "refresh_json_path": str(resolved_refresh_root / "refresh.json"),
+        "refresh_markdown_path": str(resolved_refresh_root / "refresh.md"),
     }
-    write_json(refresh_root / "refresh.json", payload)
-    write_markdown(refresh_root / "refresh.md", render_provider_refresh(payload))
+    write_json(resolved_refresh_root / "refresh.json", payload)
+    write_markdown(resolved_refresh_root / "refresh.md", render_provider_refresh(payload))
     write_json(provider_refresh_latest_json_path(resolved_project_root, provider), payload)
     write_markdown(
         provider_refresh_latest_markdown_path(resolved_project_root, provider),
@@ -253,6 +266,4 @@ def refresh_provider_corpus(
             "promotion": bool(promotion_result),
         },
     )
-    payload["refresh_json_path"] = str(refresh_root / "refresh.json")
-    payload["refresh_markdown_path"] = str(refresh_root / "refresh.md")
     return payload

--- a/src/conversation_corpus_engine/surface_exports.py
+++ b/src/conversation_corpus_engine/surface_exports.py
@@ -11,6 +11,7 @@ from .corpus_candidates import (
     corpus_live_pointer_path,
     corpus_promotion_latest_json_path,
 )
+from .corpus_store import CORPUS_STORE_ROOT_ENV
 from .federated_canon import load_federated_review_queue
 from .federation import (
     federation_report_path,
@@ -41,6 +42,7 @@ SURFACE_MANIFEST_CONTRACT = "conversation-corpus-engine-surface-manifest-v1"
 MCP_CONTEXT_CONTRACT = "conversation-corpus-engine-mcp-context-v1"
 SURFACE_BUNDLE_CONTRACT = "conversation-corpus-engine-surface-bundle-v1"
 SURFACE_CONTRACT_VERSION = 1
+CORPUS_STORE_ROOT_PLACEHOLDER = f"${{{CORPUS_STORE_ROOT_ENV}}}"
 
 CLI_SURFACES = [
     {
@@ -264,6 +266,28 @@ def surface_bundle_markdown_path(project_root: Path) -> Path:
 
 def optional_json(path: Path) -> Any:
     return load_json(path, default=None)
+
+
+def _redact_path_prefix(payload: Any, path_prefix: str) -> Any:
+    if isinstance(payload, str):
+        return payload.replace(path_prefix, CORPUS_STORE_ROOT_PLACEHOLDER)
+    if isinstance(payload, list):
+        return [_redact_path_prefix(item, path_prefix) for item in payload]
+    if isinstance(payload, dict):
+        return {key: _redact_path_prefix(value, path_prefix) for key, value in payload.items()}
+    return payload
+
+
+def redact_corpus_store_paths(payload: Any, registry: dict[str, Any]) -> Any:
+    registration = registry.get("corpus_store")
+    if (
+        not isinstance(registration, dict)
+        or registration.get("status") != "active"
+        or not isinstance(registration.get("root"), str)
+    ):
+        return payload
+    store_root = str(Path(registration["root"]).resolve())
+    return _redact_path_prefix(payload, store_root)
 
 
 def build_commercial_awareness_payload() -> dict[str, Any]:
@@ -558,7 +582,7 @@ def build_surface_manifest(
         resolved_source_drop_root,
     )
     registry = snapshot["registry"]
-    return {
+    payload = {
         "contract_name": SURFACE_MANIFEST_CONTRACT,
         "contract_version": SURFACE_CONTRACT_VERSION,
         "generated_at": now_iso(),
@@ -619,6 +643,7 @@ def build_surface_manifest(
         },
         "commercial_awareness": build_commercial_awareness_payload(),
     }
+    return redact_corpus_store_paths(payload, registry)
 
 
 def build_mcp_context_payload(
@@ -647,7 +672,7 @@ def build_mcp_context_payload(
     refresh_recommended_count = sum(
         1 for item in providers if "cce provider refresh" in (item.get("next_command") or "")
     )
-    return {
+    payload = {
         "contract_name": MCP_CONTEXT_CONTRACT,
         "contract_version": SURFACE_CONTRACT_VERSION,
         "generated_at": now_iso(),
@@ -700,6 +725,7 @@ def build_mcp_context_payload(
         "schema_catalog": list_schemas(),
         "commercial_awareness": build_commercial_awareness_payload(),
     }
+    return redact_corpus_store_paths(payload, snapshot["registry"])
 
 
 def write_surface_manifest_artifacts(

--- a/src/conversation_corpus_engine/surface_exports.py
+++ b/src/conversation_corpus_engine/surface_exports.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -43,6 +44,21 @@ MCP_CONTEXT_CONTRACT = "conversation-corpus-engine-mcp-context-v1"
 SURFACE_BUNDLE_CONTRACT = "conversation-corpus-engine-surface-bundle-v1"
 SURFACE_CONTRACT_VERSION = 1
 CORPUS_STORE_ROOT_PLACEHOLDER = f"${{{CORPUS_STORE_ROOT_ENV}}}"
+HISTORICAL_CORPUS_ROOT_PLACEHOLDER = "<historical-corpus-root>"
+
+_CORPUS_EVENT_ROOT_FIELDS = {
+    "candidate_root",
+    "live_root",
+    "output_root",
+    "previous_root",
+    "promoted_root",
+    "restored_root",
+    "target_root",
+}
+_REFRESH_RECEIPT_FIELDS = {
+    "refresh_json_path",
+    "refresh_markdown_path",
+}
 
 CLI_SURFACES = [
     {
@@ -268,26 +284,176 @@ def optional_json(path: Path) -> Any:
     return load_json(path, default=None)
 
 
-def _redact_path_prefix(payload: Any, path_prefix: str) -> Any:
+def _replace_path_prefix(value: str, path_prefix: str, replacement: str) -> str:
+    normalized_prefix = path_prefix.rstrip("/") or "/"
+    pattern = re.compile(
+        rf"(?<![A-Za-z0-9._~/-]){re.escape(normalized_prefix)}"
+        r"(?=$|/|[\s'\"`,:;)\]}])"
+    )
+    return pattern.sub(lambda _match: replacement, value)
+
+
+def _redact_path_prefix(payload: Any, path_prefix: str, replacement: str) -> Any:
     if isinstance(payload, str):
-        return payload.replace(path_prefix, CORPUS_STORE_ROOT_PLACEHOLDER)
+        return _replace_path_prefix(payload, path_prefix, replacement)
     if isinstance(payload, list):
-        return [_redact_path_prefix(item, path_prefix) for item in payload]
+        return [_redact_path_prefix(item, path_prefix, replacement) for item in payload]
     if isinstance(payload, dict):
-        return {key: _redact_path_prefix(value, path_prefix) for key, value in payload.items()}
+        return {
+            key: _redact_path_prefix(value, path_prefix, replacement)
+            for key, value in payload.items()
+        }
     return payload
+
+
+def _absolute_path_string(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        return None
+    return str(path.resolve(strict=False))
+
+
+def _collect_named_paths(
+    payload: Any,
+    *,
+    field_names: set[str],
+    receipt_fields: set[str] | None = None,
+) -> set[str]:
+    paths: set[str] = set()
+    if isinstance(payload, list):
+        for item in payload:
+            paths.update(
+                _collect_named_paths(
+                    item,
+                    field_names=field_names,
+                    receipt_fields=receipt_fields,
+                )
+            )
+        return paths
+    if not isinstance(payload, dict):
+        return paths
+    for key, value in payload.items():
+        if key in field_names:
+            resolved = _absolute_path_string(value)
+            if resolved is not None:
+                paths.add(resolved)
+        if receipt_fields and key in receipt_fields:
+            resolved = _absolute_path_string(value)
+            if resolved is not None:
+                paths.add(str(Path(resolved).parent))
+        paths.update(
+            _collect_named_paths(
+                value,
+                field_names=field_names,
+                receipt_fields=receipt_fields,
+            )
+        )
+    return paths
+
+
+def _classified_corpus_roots(payload: Any) -> set[str]:
+    if not isinstance(payload, dict):
+        return set()
+    roots: set[str] = set()
+
+    registry = payload.get("registry")
+    if isinstance(registry, dict):
+        for entry in registry.get("corpora") or []:
+            if isinstance(entry, dict):
+                resolved = _absolute_path_string(entry.get("root"))
+                if resolved is not None:
+                    roots.add(resolved)
+
+    for provider in payload.get("providers") or []:
+        if not isinstance(provider, dict):
+            continue
+        for field in ("selected_target",):
+            target = provider.get(field)
+            if isinstance(target, dict):
+                resolved = _absolute_path_string(target.get("root"))
+                if resolved is not None:
+                    roots.add(resolved)
+        for field in ("selected_targets", "targets"):
+            for target in provider.get(field) or []:
+                if isinstance(target, dict):
+                    resolved = _absolute_path_string(target.get("root"))
+                    if resolved is not None:
+                        roots.add(resolved)
+        policy = provider.get("source_policy")
+        if isinstance(policy, dict):
+            for field in ("primary_root", "fallback_root"):
+                resolved = _absolute_path_string(policy.get(field))
+                if resolved is not None:
+                    roots.add(resolved)
+
+    governance = payload.get("governance")
+    if isinstance(governance, dict):
+        for field in ("latest_corpus_candidate", "latest_corpus_promotion"):
+            roots.update(
+                _collect_named_paths(
+                    governance.get(field),
+                    field_names=_CORPUS_EVENT_ROOT_FIELDS,
+                )
+            )
+
+    latest_events = payload.get("latest_events")
+    if isinstance(latest_events, dict):
+        roots.update(
+            _collect_named_paths(
+                latest_events.get("latest_corpus_live_pointer"),
+                field_names=_CORPUS_EVENT_ROOT_FIELDS,
+            )
+        )
+        roots.update(
+            _collect_named_paths(
+                latest_events.get("latest_provider_refreshes"),
+                field_names=_CORPUS_EVENT_ROOT_FIELDS,
+                receipt_fields=_REFRESH_RECEIPT_FIELDS,
+            )
+        )
+    return roots
 
 
 def redact_corpus_store_paths(payload: Any, registry: dict[str, Any]) -> Any:
     registration = registry.get("corpus_store")
-    if (
-        not isinstance(registration, dict)
-        or registration.get("status") != "active"
-        or not isinstance(registration.get("root"), str)
-    ):
-        return payload
-    store_root = str(Path(registration["root"]).resolve())
-    return _redact_path_prefix(payload, store_root)
+    active_store_root = (
+        str(Path(registration["root"]).resolve())
+        if (
+            isinstance(registration, dict)
+            and registration.get("status") == "active"
+            and isinstance(registration.get("root"), str)
+        )
+        else None
+    )
+    redacted = payload
+    if active_store_root is not None:
+        redacted = _redact_path_prefix(
+            redacted,
+            active_store_root,
+            CORPUS_STORE_ROOT_PLACEHOLDER,
+        )
+
+    classified_roots = _classified_corpus_roots(payload)
+    historical_roots = {
+        root
+        for root in classified_roots
+        if not (
+            active_store_root
+            and (
+                Path(root) == Path(active_store_root)
+                or Path(root).is_relative_to(Path(active_store_root))
+            )
+        )
+    }
+    for historical_root in sorted(historical_roots, key=len):
+        redacted = _redact_path_prefix(
+            redacted,
+            historical_root,
+            HISTORICAL_CORPUS_ROOT_PLACEHOLDER,
+        )
+    return redacted
 
 
 def build_commercial_awareness_payload() -> dict[str, Any]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,6 +63,81 @@ def test_main_federation_build_prints_json_payload(
     assert payload == {"project_root": str(tmp_path), "built": True}
 
 
+def test_main_corpus_store_register_forwards_root_and_project(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    calls: dict[str, Path] = {}
+
+    def fake_register(project_root: Path, root: Path) -> dict[str, str]:
+        calls["project_root"] = project_root
+        calls["root"] = root
+        return {"root": str(root), "status": "active", "registered_at": "now"}
+
+    monkeypatch.setattr(MODULE, "register_corpus_store", fake_register)
+
+    _run_main(
+        monkeypatch,
+        [
+            "corpus-store",
+            "register",
+            "--project-root",
+            str(tmp_path / "project"),
+            "--root",
+            str(tmp_path / "store"),
+        ],
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert calls == {
+        "project_root": tmp_path / "project",
+        "root": tmp_path / "store",
+    }
+    assert payload["status"] == "active"
+
+
+def test_main_provider_write_commands_forward_corpus_store_root(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    project_root = tmp_path / "project"
+    corpus_store_root = tmp_path / "store"
+    calls: dict[str, dict[str, object]] = {}
+
+    def fake_import(**kwargs: object) -> dict[str, object]:
+        calls["import"] = kwargs
+        return {"provider": kwargs["provider"]}
+
+    def fake_bootstrap(**kwargs: object) -> dict[str, object]:
+        calls["bootstrap"] = kwargs
+        return {"provider": kwargs["provider"]}
+
+    def fake_refresh(**kwargs: object) -> dict[str, object]:
+        calls["refresh"] = kwargs
+        return {"provider": kwargs["provider"]}
+
+    monkeypatch.setattr(MODULE, "import_provider_corpus", fake_import)
+    monkeypatch.setattr(MODULE, "bootstrap_provider_evaluation", fake_bootstrap)
+    monkeypatch.setattr(MODULE, "refresh_provider_corpus", fake_refresh)
+
+    common = [
+        "--provider",
+        "perplexity",
+        "--project-root",
+        str(project_root),
+        "--corpus-store-root",
+        str(corpus_store_root),
+    ]
+    _run_main(monkeypatch, ["provider", "import", *common])
+    capsys.readouterr()
+    _run_main(monkeypatch, ["provider", "bootstrap-eval", *common])
+    capsys.readouterr()
+    _run_main(monkeypatch, ["provider", "refresh", *common])
+    capsys.readouterr()
+
+    for kwargs in calls.values():
+        assert kwargs["project_root"] == project_root
+        assert kwargs["corpus_store_root"] == corpus_store_root
+
+
 def test_main_provider_readiness_json_mode_writes_reports(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
 ) -> None:
@@ -231,10 +306,14 @@ def test_main_evaluation_run_json_mode_prints_scorecard_and_outputs(
         seed: bool,
         markdown_output: Path | None,
         json_output: Path | None,
+        project_root: Path,
+        corpus_store_root: Path | None,
     ) -> tuple[dict[str, object], dict[str, Path]]:
         assert seed is True
         assert markdown_output == root / "answer.md"
         assert json_output == root / "answer.json"
+        assert project_root == tmp_path / "project"
+        assert corpus_store_root == tmp_path / "store"
         return (
             {"overall_state": "pass"},
             {
@@ -252,6 +331,10 @@ def test_main_evaluation_run_json_mode_prints_scorecard_and_outputs(
             "run",
             "--root",
             str(root),
+            "--project-root",
+            str(tmp_path / "project"),
+            "--corpus-store-root",
+            str(tmp_path / "store"),
             "--seed",
             "--markdown-output",
             str(root / "answer.md"),

--- a/tests/test_corpus_store.py
+++ b/tests/test_corpus_store.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from conversation_corpus_engine.corpus_store import (
+    CORPUS_STORE_ROOT_ENV,
+    CorpusStoreError,
+    authorize_corpus_write,
+    register_corpus_store,
+    resolve_configured_corpus_store_root,
+)
+from conversation_corpus_engine.federation import REGISTRY_VERSION, registry_path
+
+
+def _make_project_and_store(tmp_path: Path) -> tuple[Path, Path]:
+    project_root = tmp_path / "project"
+    store_root = tmp_path / "private-corpus-store"
+    project_root.mkdir(parents=True)
+    store_root.mkdir()
+    register_corpus_store(project_root, store_root)
+    return project_root, store_root
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_git_repo(repo: Path) -> None:
+    repo.mkdir()
+    _git(repo, "init")
+
+
+def _tree_snapshot(root: Path) -> dict[str, bytes | str]:
+    snapshot: dict[str, bytes | str] = {}
+    for path in sorted(root.rglob("*")):
+        relative = str(path.relative_to(root))
+        if path.is_symlink():
+            snapshot[relative] = f"symlink:{path.readlink()}"
+        elif path.is_file():
+            snapshot[relative] = path.read_bytes()
+        else:
+            snapshot[relative] = "directory"
+    return snapshot
+
+
+def test_registration_writes_v2_and_same_root_is_byte_idempotent(tmp_path: Path) -> None:
+    project_root, store_root = _make_project_and_store(tmp_path)
+    path = registry_path(project_root)
+    before = path.read_bytes()
+
+    registration = register_corpus_store(project_root, store_root)
+
+    assert path.read_bytes() == before
+    registry = json.loads(before)
+    assert registry["registry_version"] == REGISTRY_VERSION == 2
+    assert registry["corpus_store"] == registration
+    assert registry["corpora"] == []
+
+
+def test_different_registration_replaces_singular_store_without_history(tmp_path: Path) -> None:
+    project_root, first_store = _make_project_and_store(tmp_path)
+    second_store = tmp_path / "second-store"
+    second_store.mkdir()
+    first_registration = register_corpus_store(project_root, first_store)
+
+    second_registration = register_corpus_store(project_root, second_store)
+
+    registry = json.loads(registry_path(project_root).read_text())
+    assert registry["corpus_store"] == second_registration
+    assert registry["corpus_store"]["root"] == str(second_store.resolve())
+    assert first_registration["root"] not in json.dumps(registry["corpus_store"])
+    assert "corpus_stores" not in registry
+
+
+def test_explicit_configuration_precedes_environment(tmp_path: Path) -> None:
+    project_root, store_root = _make_project_and_store(tmp_path)
+    other_store = tmp_path / "other-store"
+    other_store.mkdir()
+
+    resolved = resolve_configured_corpus_store_root(
+        store_root,
+        environ={CORPUS_STORE_ROOT_ENV: str(other_store)},
+    )
+    authorization = authorize_corpus_write(
+        project_root=project_root,
+        corpus_store_root=resolved,
+        destination=store_root / "corpus-a",
+    )
+
+    assert authorization.store_root == store_root.resolve()
+    assert authorization.destination == (store_root / "corpus-a").resolve()
+
+
+def test_environment_configuration_is_used_when_cli_value_is_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project_root, store_root = _make_project_and_store(tmp_path)
+    monkeypatch.setenv(CORPUS_STORE_ROOT_ENV, str(store_root))
+
+    authorization = authorize_corpus_write(
+        project_root=project_root,
+        destination=store_root / "corpus-a",
+    )
+
+    assert authorization.store_root == store_root.resolve()
+
+
+def test_missing_configuration_and_unregistered_root_create_nothing(tmp_path: Path) -> None:
+    project_root, store_root = _make_project_and_store(tmp_path)
+    other_store = tmp_path / "other-store"
+    other_store.mkdir()
+    missing_destination = store_root / "missing" / "corpus"
+    before = _tree_snapshot(tmp_path)
+
+    with pytest.raises(CorpusStoreError, match="not configured"):
+        authorize_corpus_write(
+            project_root=project_root,
+            destination=missing_destination,
+            corpus_store_root=None,
+        )
+    with pytest.raises(CorpusStoreError, match="does not match"):
+        authorize_corpus_write(
+            project_root=project_root,
+            corpus_store_root=other_store,
+            destination=other_store / "corpus",
+        )
+
+    assert _tree_snapshot(tmp_path) == before
+    assert not missing_destination.exists()
+
+
+def test_outside_git_and_git_ignored_roots_are_accepted(tmp_path: Path) -> None:
+    project_root, store_root = _make_project_and_store(tmp_path / "outside")
+    assert authorize_corpus_write(
+        project_root=project_root,
+        corpus_store_root=store_root,
+        destination=store_root / "corpus",
+    )
+
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    (repo / ".gitignore").write_text("private/\nstate/\n", encoding="utf-8")
+    ignored_store = repo / "private"
+    ignored_store.mkdir()
+    register_corpus_store(repo, ignored_store)
+
+    assert authorize_corpus_write(
+        project_root=repo,
+        corpus_store_root=ignored_store,
+        destination=ignored_store / "corpus",
+    )
+
+
+def test_tracked_content_and_ignore_negation_are_rejected(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    (repo / ".gitignore").write_text("private/\nstate/\n", encoding="utf-8")
+    store_root = repo / "private"
+    store_root.mkdir()
+    tracked = store_root / "tracked.txt"
+    tracked.write_text("tracked\n", encoding="utf-8")
+    _git(repo, "add", "-f", "private/tracked.txt")
+
+    with pytest.raises(CorpusStoreError, match="tracked"):
+        register_corpus_store(repo, store_root)
+
+    _git(repo, "rm", "--cached", "private/tracked.txt")
+    register_corpus_store(repo, store_root)
+    visible = store_root / "visible.txt"
+    visible.write_text("visible\n", encoding="utf-8")
+    (repo / ".gitignore").write_text(
+        "private/*\n!private/visible.txt\nstate/\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CorpusStoreError, match="Git-visible|negation"):
+        authorize_corpus_write(
+            project_root=repo,
+            corpus_store_root=store_root,
+            destination=store_root / "corpus",
+        )
+
+
+def test_registered_root_that_becomes_git_visible_is_rejected(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    ignore_path = repo / ".gitignore"
+    ignore_path.write_text("private/\nstate/\n", encoding="utf-8")
+    store_root = repo / "private"
+    store_root.mkdir()
+    register_corpus_store(repo, store_root)
+    ignore_path.write_text("state/\n", encoding="utf-8")
+
+    with pytest.raises(CorpusStoreError, match="Git-visible"):
+        authorize_corpus_write(
+            project_root=repo,
+            corpus_store_root=store_root,
+            destination=store_root / "corpus",
+        )
+
+
+@pytest.mark.parametrize(
+    ("destination_kind", "message"),
+    [
+        ("equal", "strict descendant"),
+        ("outside", "strict descendant"),
+        ("source_parent", "overlap"),
+        ("source_child", "overlap"),
+    ],
+)
+def test_containment_and_bidirectional_overlap_are_rejected(
+    tmp_path: Path, destination_kind: str, message: str
+) -> None:
+    project_root, store_root = _make_project_and_store(tmp_path)
+    corpus_root = store_root / "corpus"
+    source_child = corpus_root / "source"
+    source_child.mkdir(parents=True)
+    if destination_kind == "equal":
+        destination = store_root
+        source_roots: tuple[Path, ...] = ()
+    elif destination_kind == "outside":
+        destination = tmp_path / "outside"
+        source_roots = ()
+    elif destination_kind == "source_parent":
+        destination = corpus_root / "candidate"
+        source_roots = (corpus_root,)
+    else:
+        destination = corpus_root
+        source_roots = (source_child,)
+
+    with pytest.raises(CorpusStoreError, match=message):
+        authorize_corpus_write(
+            project_root=project_root,
+            corpus_store_root=store_root,
+            destination=destination,
+            source_roots=source_roots,
+        )
+
+
+def test_root_and_descendant_symlinks_are_rejected(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    actual_store = tmp_path / "actual-store"
+    actual_store.mkdir()
+    linked_store = tmp_path / "linked-store"
+    linked_store.symlink_to(actual_store, target_is_directory=True)
+
+    with pytest.raises(CorpusStoreError, match="symlink"):
+        register_corpus_store(project_root, linked_store)
+
+    register_corpus_store(project_root, actual_store)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    linked_child = actual_store / "linked-child"
+    linked_child.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(CorpusStoreError, match="symlink"):
+        authorize_corpus_write(
+            project_root=project_root,
+            corpus_store_root=actual_store,
+            destination=linked_child / "corpus",
+        )
+
+
+def test_nested_clone_incident_replay_is_rejected_without_writes(tmp_path: Path) -> None:
+    project_root, store_root = _make_project_and_store(tmp_path)
+    nested = store_root / "candidate"
+    (nested / ".git").mkdir(parents=True)
+    destination = nested / "corpus"
+    before = _tree_snapshot(tmp_path)
+
+    with pytest.raises(CorpusStoreError, match="nested Git"):
+        authorize_corpus_write(
+            project_root=project_root,
+            corpus_store_root=store_root,
+            destination=destination,
+        )
+
+    assert _tree_snapshot(tmp_path) == before
+    assert not destination.exists()
+
+
+def test_malformed_registry_denial_does_not_bootstrap_or_rewrite(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    store_root = tmp_path / "store"
+    project_root.mkdir()
+    store_root.mkdir()
+    path = registry_path(project_root)
+    path.parent.mkdir()
+    path.write_text("{malformed", encoding="utf-8")
+    before = _tree_snapshot(tmp_path)
+
+    with pytest.raises(CorpusStoreError, match="malformed"):
+        authorize_corpus_write(
+            project_root=project_root,
+            corpus_store_root=store_root,
+            destination=store_root / "corpus",
+        )
+
+    assert _tree_snapshot(tmp_path) == before

--- a/tests/test_evaluation_bootstrap.py
+++ b/tests/test_evaluation_bootstrap.py
@@ -13,6 +13,7 @@ from conversation_corpus_engine.evaluation_bootstrap import (
     bootstrap_claude_evaluation,
     bootstrap_provider_evaluation,
 )
+from conversation_corpus_engine.federation import upsert_corpus
 
 
 def seed_eval_target(root: Path, *, corpus_id: str, name: str, adapter_type: str) -> None:
@@ -115,6 +116,37 @@ def seed_eval_target(root: Path, *, corpus_id: str, name: str, adapter_type: str
 
 
 class EvaluationBootstrapTests(unittest.TestCase):
+    def test_bootstrap_provider_resolves_registered_store_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            project_root.mkdir()
+            corpus_store_root = Path(tmpdir) / "corpus-store"
+            corpus_store_root.mkdir()
+            target_root = corpus_store_root / "perplexity-history-memory"
+            seed_eval_target(
+                target_root,
+                corpus_id="perplexity-history-memory",
+                name="Perplexity History Memory",
+                adapter_type="perplexity-export",
+            )
+            register_corpus_store(project_root, corpus_store_root)
+            upsert_corpus(
+                project_root,
+                target_root,
+                corpus_id="perplexity-history-memory",
+                name="Perplexity History Memory",
+            )
+
+            payload = bootstrap_provider_evaluation(
+                project_root=project_root,
+                provider="perplexity",
+                corpus_store_root=corpus_store_root,
+            )
+
+            self.assertEqual(payload["resolution_source"], "primary")
+            self.assertEqual(payload["target_root"], str(target_root.resolve()))
+            self.assertTrue((target_root / "eval" / "manual-review-guide.md").exists())
+
     def test_bootstrap_explicit_target_writes_provider_report(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "project"

--- a/tests/test_evaluation_bootstrap.py
+++ b/tests/test_evaluation_bootstrap.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+from conversation_corpus_engine.corpus_store import CorpusStoreError, register_corpus_store
 from conversation_corpus_engine.evaluation_bootstrap import (
     bootstrap_claude_evaluation,
     bootstrap_provider_evaluation,
@@ -117,19 +118,23 @@ class EvaluationBootstrapTests(unittest.TestCase):
     def test_bootstrap_explicit_target_writes_provider_report(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "project"
-            target_root = Path(tmpdir) / "gemini-history-memory"
             project_root.mkdir(parents=True, exist_ok=True)
+            corpus_store_root = Path(tmpdir) / "corpus-store"
+            corpus_store_root.mkdir()
+            target_root = corpus_store_root / "gemini-history-memory"
             seed_eval_target(
                 target_root,
                 corpus_id="gemini-history-memory",
                 name="Gemini History Memory",
                 adapter_type="gemini-export",
             )
+            register_corpus_store(project_root, corpus_store_root)
 
             payload = bootstrap_provider_evaluation(
                 project_root=project_root,
                 provider="gemini",
                 target_root=target_root,
+                corpus_store_root=corpus_store_root,
             )
 
             self.assertEqual(payload["provider"], "gemini")
@@ -140,11 +145,40 @@ class EvaluationBootstrapTests(unittest.TestCase):
                 (project_root / "reports" / "gemini-evaluation-bootstrap-latest.md").exists()
             )
 
+    def test_bootstrap_denial_does_not_seed_or_write_project_report(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            project_root.mkdir()
+            corpus_store_root = Path(tmpdir) / "corpus-store"
+            corpus_store_root.mkdir()
+            register_corpus_store(project_root, corpus_store_root)
+            outside_target = Path(tmpdir) / "outside-corpus"
+            seed_eval_target(
+                outside_target,
+                corpus_id="gemini-history-memory",
+                name="Gemini History Memory",
+                adapter_type="gemini-export",
+            )
+
+            with self.assertRaises(CorpusStoreError):
+                bootstrap_provider_evaluation(
+                    project_root=project_root,
+                    provider="gemini",
+                    target_root=outside_target,
+                    corpus_store_root=corpus_store_root,
+                )
+
+            self.assertFalse((outside_target / "eval" / "gold").exists())
+            self.assertFalse((outside_target / "eval" / "manual-review-guide.md").exists())
+            self.assertFalse((project_root / "reports").exists())
+
     def test_bootstrap_claude_uses_policy_primary_root_and_can_run_full_eval(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "project"
-            target_root = Path(tmpdir) / "claude-local-session-memory"
             project_root.mkdir(parents=True, exist_ok=True)
+            corpus_store_root = Path(tmpdir) / "corpus-store"
+            corpus_store_root.mkdir()
+            target_root = corpus_store_root / "claude-local-session-memory"
             seed_eval_target(
                 target_root,
                 corpus_id="claude-local-session-memory",
@@ -162,11 +196,13 @@ class EvaluationBootstrapTests(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
+            register_corpus_store(project_root, corpus_store_root)
 
             payload = bootstrap_claude_evaluation(
                 project_root=project_root,
                 policy_path=policy_path,
                 full_eval=True,
+                corpus_store_root=corpus_store_root,
             )
 
             self.assertEqual(payload["target_root"], str(target_root.resolve()))

--- a/tests/test_evaluation_bootstrap.py
+++ b/tests/test_evaluation_bootstrap.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import re
+import shlex
 import sys
 import tempfile
 import unittest
@@ -116,6 +118,85 @@ def seed_eval_target(root: Path, *, corpus_id: str, name: str, adapter_type: str
 
 
 class EvaluationBootstrapTests(unittest.TestCase):
+    def test_manual_guide_commands_quote_authorized_project_and_store_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace_root = Path(tmpdir)
+            project_root = workspace_root / "project with spaces"
+            project_root.mkdir()
+            corpus_store_root = workspace_root / "corpus store"
+            corpus_store_root.mkdir()
+            target_root = corpus_store_root / "gemini history memory"
+            seed_eval_target(
+                target_root,
+                corpus_id="gemini-history-memory",
+                name="Gemini History Memory",
+                adapter_type="gemini-export",
+            )
+            register_corpus_store(project_root, corpus_store_root)
+
+            payload = bootstrap_provider_evaluation(
+                project_root=project_root,
+                provider="gemini",
+                target_root=target_root,
+                corpus_store_root=corpus_store_root,
+            )
+
+            guide = Path(payload["manual_guide_path"]).read_text(encoding="utf-8")
+            commands = re.findall(r"`(cce [^`]+)`", guide)
+            parsed_commands = [shlex.split(command) for command in commands]
+
+            self.assertEqual(len(parsed_commands), 2)
+            for parsed in parsed_commands:
+                self.assertEqual(
+                    parsed[parsed.index("--project-root") + 1],
+                    str(project_root.resolve()),
+                )
+                self.assertEqual(
+                    parsed[parsed.index("--corpus-store-root") + 1],
+                    str(corpus_store_root.resolve()),
+                )
+            self.assertEqual(
+                parsed_commands[0][parsed_commands[0].index("--root") + 1],
+                str(target_root.resolve()),
+            )
+            self.assertEqual(
+                parsed_commands[1][parsed_commands[1].index("--target-root") + 1],
+                str(target_root.resolve()),
+            )
+            self.assertEqual(
+                parsed_commands[1][parsed_commands[1].index("--provider") + 1],
+                "gemini",
+            )
+
+    def test_manual_guide_omits_provider_bootstrap_without_real_provider(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            project_root.mkdir()
+            corpus_store_root = Path(tmpdir) / "corpus-store"
+            corpus_store_root.mkdir()
+            target_root = corpus_store_root / "external-memory"
+            seed_eval_target(
+                target_root,
+                corpus_id="external-memory",
+                name="External Memory",
+                adapter_type="external-export",
+            )
+            register_corpus_store(project_root, corpus_store_root)
+
+            payload = bootstrap_provider_evaluation(
+                project_root=project_root,
+                provider=None,
+                target_root=target_root,
+                corpus_store_root=corpus_store_root,
+            )
+
+            guide = Path(payload["manual_guide_path"]).read_text(encoding="utf-8")
+            commands = re.findall(r"`(cce [^`]+)`", guide)
+
+            self.assertEqual(len(commands), 1)
+            self.assertTrue(commands[0].startswith("cce evaluation run "))
+            self.assertNotIn("provider bootstrap-eval", guide)
+
     def test_bootstrap_provider_resolves_registered_store_target(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "project"

--- a/tests/test_import_chatgpt_export_corpus.py
+++ b/tests/test_import_chatgpt_export_corpus.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+from conversation_corpus_engine.corpus_store import register_corpus_store  # noqa: E402
 from conversation_corpus_engine.import_chatgpt_export_corpus import (  # noqa: E402
     import_chatgpt_export_corpus,
 )
@@ -123,13 +124,18 @@ class ChatGPTProviderIntegrationTests(unittest.TestCase):
     def test_import_provider_corpus_routes_chatgpt(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "project"
+            project_root.mkdir()
+            corpus_store_root = Path(tmpdir) / "corpus-store"
+            corpus_store_root.mkdir()
+            register_corpus_store(project_root, corpus_store_root)
             source_path = FIXTURE_ROOT
-            output_root = Path(tmpdir) / "chatgpt-history-memory"
+            output_root = corpus_store_root / "chatgpt-history-memory"
             result = import_provider_corpus(
                 project_root=project_root,
                 provider="chatgpt",
                 source_path=source_path,
                 output_root=output_root,
+                corpus_store_root=corpus_store_root,
                 bootstrap_eval=False,
             )
             self.assertEqual(result["provider"], "chatgpt")

--- a/tests/test_provider_import.py
+++ b/tests/test_provider_import.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+from conversation_corpus_engine.corpus_store import CorpusStoreError, register_corpus_store
 from conversation_corpus_engine.federation import list_registered_corpora
 from conversation_corpus_engine.provider_import import import_provider_corpus
 from conversation_corpus_engine.provider_readiness import build_provider_readiness
@@ -18,6 +19,10 @@ class ProviderImportTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace_root = Path(tmpdir)
             project_root = workspace_root / "project"
+            project_root.mkdir()
+            corpus_store_root = workspace_root / "corpus-store"
+            corpus_store_root.mkdir()
+            register_corpus_store(project_root, corpus_store_root)
             source_drop_root = workspace_root / "source-drop"
             inbox = source_drop_root / "perplexity" / "inbox"
             inbox.mkdir(parents=True, exist_ok=True)
@@ -30,6 +35,7 @@ class ProviderImportTests(unittest.TestCase):
                 project_root=project_root,
                 provider="perplexity",
                 source_drop_root=source_drop_root,
+                corpus_store_root=corpus_store_root,
                 register=True,
                 build=True,
             )
@@ -46,6 +52,10 @@ class ProviderImportTests(unittest.TestCase):
             )
 
             self.assertEqual(result["corpus_id"], "perplexity-history-memory")
+            self.assertEqual(
+                Path(result["output_root"]).resolve(),
+                (corpus_store_root / "perplexity-history-memory").resolve(),
+            )
             self.assertEqual(contract["adapter_type"], "perplexity-export")
             self.assertEqual(len(registry), 1)
             self.assertEqual(registry[0]["corpus_id"], "perplexity-history-memory")
@@ -54,6 +64,35 @@ class ProviderImportTests(unittest.TestCase):
             self.assertTrue(Path(result["bootstrap_result"]["seeded_paths"]["answers"]).exists())
             self.assertEqual(perplexity["overall_state"], "manual-eval-pending")
             self.assertIn("cce evaluation run --root", perplexity["next_command"])
+
+    def test_import_denial_creates_no_destination_or_control_plane_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace_root = Path(tmpdir)
+            project_root = workspace_root / "project"
+            project_root.mkdir()
+            corpus_store_root = workspace_root / "corpus-store"
+            corpus_store_root.mkdir()
+            register_corpus_store(project_root, corpus_store_root)
+            source_drop_root = workspace_root / "source-drop"
+            inbox = source_drop_root / "perplexity" / "inbox"
+            inbox.mkdir(parents=True)
+            (inbox / "export.md").write_text("# Export\n\nPrivate custody required.\n")
+            outside_destination = workspace_root / "visible-output"
+            registry_path = project_root / "state" / "federation-registry.json"
+            registry_before = registry_path.read_bytes()
+
+            with self.assertRaises(CorpusStoreError):
+                import_provider_corpus(
+                    project_root=project_root,
+                    provider="perplexity",
+                    source_drop_root=source_drop_root,
+                    corpus_store_root=corpus_store_root,
+                    output_root=outside_destination,
+                )
+
+            self.assertFalse(outside_destination.exists())
+            self.assertEqual(registry_path.read_bytes(), registry_before)
+            self.assertFalse((project_root / "reports").exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_provider_readiness.py
+++ b/tests/test_provider_readiness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 import sys
 import tempfile
 import unittest
@@ -126,6 +127,100 @@ class ProviderReadinessTests(unittest.TestCase):
                     f"--project-root {project_root.resolve()} "
                     "--root /path/to/private-corpus-store"
                 ),
+            )
+
+    def test_legacy_out_of_store_bootstrap_target_emits_migration_guidance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            project_root.mkdir()
+            source_drop_root = Path(tmpdir) / "source-drop"
+            corpus_store_root = Path(tmpdir) / "corpus-store"
+            corpus_store_root.mkdir()
+            legacy_root = Path(tmpdir) / "perplexity-history-memory"
+            seed_valid_corpus(legacy_root)
+            (legacy_root / "eval" / "manual-review-guide.md").unlink()
+            upsert_corpus(
+                project_root,
+                legacy_root,
+                corpus_id="perplexity-history-memory",
+                name="Perplexity History Memory",
+            )
+            register_corpus_store(project_root, corpus_store_root)
+
+            payload = build_provider_readiness(project_root, source_drop_root)
+            readiness = next(
+                item for item in payload["providers"] if item["provider"] == "perplexity"
+            )
+
+            self.assertEqual(readiness["overall_state"], "imported-needs-bootstrap")
+            self.assertIn("Migrate or re-import", readiness["next_command"])
+            self.assertIn(str(corpus_store_root.resolve()), readiness["next_command"])
+            self.assertNotIn("cce provider bootstrap-eval", readiness["next_command"])
+
+    def test_missing_target_import_remains_store_backed_and_executable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project with spaces"
+            project_root.mkdir()
+            source_drop_root = Path(tmpdir) / "source drop"
+            inbox = source_drop_root / "perplexity" / "inbox"
+            inbox.mkdir(parents=True)
+            (inbox / "export.md").write_text("# export\n", encoding="utf-8")
+            corpus_store_root = Path(tmpdir) / "corpus store"
+            corpus_store_root.mkdir()
+            register_corpus_store(project_root, corpus_store_root)
+
+            payload = build_provider_readiness(project_root, source_drop_root)
+            readiness = next(
+                item for item in payload["providers"] if item["provider"] == "perplexity"
+            )
+            command = shlex.split(readiness["next_command"])
+
+            self.assertEqual(readiness["overall_state"], "missing")
+            self.assertEqual(command[:4], ["cce", "provider", "import", "--provider"])
+            self.assertEqual(
+                command[command.index("--project-root") + 1],
+                str(project_root.resolve()),
+            )
+            self.assertEqual(
+                command[command.index("--source-drop-root") + 1],
+                str(source_drop_root.resolve()),
+            )
+            self.assertEqual(
+                command[command.index("--corpus-store-root") + 1],
+                str(corpus_store_root.resolve()),
+            )
+
+    def test_healthy_legacy_target_refresh_remains_store_backed_and_executable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            project_root.mkdir()
+            source_drop_root = Path(tmpdir) / "source-drop"
+            inbox = source_drop_root / "perplexity" / "inbox"
+            inbox.mkdir(parents=True)
+            (inbox / "export.md").write_text("# export\n", encoding="utf-8")
+            corpus_store_root = Path(tmpdir) / "corpus-store"
+            corpus_store_root.mkdir()
+            legacy_root = Path(tmpdir) / "perplexity-history-memory"
+            seed_valid_corpus(legacy_root)
+            upsert_corpus(
+                project_root,
+                legacy_root,
+                corpus_id="perplexity-history-memory",
+                name="Perplexity History Memory",
+            )
+            register_corpus_store(project_root, corpus_store_root)
+
+            payload = build_provider_readiness(project_root, source_drop_root)
+            readiness = next(
+                item for item in payload["providers"] if item["provider"] == "perplexity"
+            )
+            command = shlex.split(readiness["next_command"])
+
+            self.assertEqual(readiness["overall_state"], "healthy-federation")
+            self.assertEqual(command[:4], ["cce", "provider", "refresh", "--provider"])
+            self.assertEqual(
+                command[command.index("--corpus-store-root") + 1],
+                str(corpus_store_root.resolve()),
             )
 
     def test_build_provider_readiness_prefers_registered_chatgpt_fallback_when_default_missing(

--- a/tests/test_provider_readiness.py
+++ b/tests/test_provider_readiness.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+from conversation_corpus_engine.corpus_store import register_corpus_store
 from conversation_corpus_engine.federation import list_registered_corpora, upsert_corpus
 from conversation_corpus_engine.provider_discovery import discover_provider_uploads
 from conversation_corpus_engine.provider_readiness import build_provider_readiness
@@ -73,13 +74,17 @@ class ProviderReadinessTests(unittest.TestCase):
     def test_build_provider_readiness_reports_registered_active_corpus(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "project"
+            project_root.mkdir()
             source_drop_root = Path(tmpdir) / "source-drop"
             inbox = source_drop_root / "perplexity" / "inbox"
             inbox.mkdir(parents=True, exist_ok=True)
             (inbox / "export.md").write_text("# export\n", encoding="utf-8")
 
-            corpus_root = source_drop_root.parent / "perplexity-history-memory"
+            corpus_store_root = Path(tmpdir) / "corpus-store"
+            corpus_store_root.mkdir()
+            corpus_root = corpus_store_root / "perplexity-history-memory"
             seed_valid_corpus(corpus_root)
+            register_corpus_store(project_root, corpus_store_root)
             upsert_corpus(
                 project_root,
                 corpus_root,
@@ -95,7 +100,33 @@ class ProviderReadinessTests(unittest.TestCase):
 
             self.assertEqual(readiness["overall_state"], "healthy-federation")
             self.assertIn("cce provider refresh --provider perplexity", readiness["next_command"])
+            self.assertIn(
+                f"--corpus-store-root {corpus_store_root.resolve()}",
+                readiness["next_command"],
+            )
             self.assertEqual(len(corpora), 1)
+
+    def test_build_provider_readiness_requires_store_setup_before_import(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            source_drop_root = Path(tmpdir) / "source-drop"
+            inbox = source_drop_root / "perplexity" / "inbox"
+            inbox.mkdir(parents=True, exist_ok=True)
+            (inbox / "export.md").write_text("# export\n", encoding="utf-8")
+
+            payload = build_provider_readiness(project_root, source_drop_root)
+            readiness = next(
+                item for item in payload["providers"] if item["provider"] == "perplexity"
+            )
+
+            self.assertEqual(
+                readiness["next_command"],
+                (
+                    "cce corpus-store register "
+                    f"--project-root {project_root.resolve()} "
+                    "--root /path/to/private-corpus-store"
+                ),
+            )
 
     def test_build_provider_readiness_prefers_registered_chatgpt_fallback_when_default_missing(
         self,

--- a/tests/test_provider_refresh.py
+++ b/tests/test_provider_refresh.py
@@ -5,12 +5,15 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+import conversation_corpus_engine.provider_refresh as provider_refresh_module
 from conversation_corpus_engine.corpus_store import register_corpus_store
 from conversation_corpus_engine.federation import list_registered_corpora, upsert_corpus
 from conversation_corpus_engine.provider_refresh import refresh_provider_corpus
+from conversation_corpus_engine.schema_validation import validate_json_file
 from conversation_corpus_engine.source_policy import load_source_policy, set_source_policy
 
 
@@ -54,7 +57,85 @@ def seed_valid_corpus(
     (root / "eval" / "manual-review-guide.md").write_text("# Manual Review\n", encoding="utf-8")
 
 
+def tree_snapshot(root: Path) -> dict[str, bytes]:
+    return {
+        str(path.relative_to(root)): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
 class ProviderRefreshTests(unittest.TestCase):
+    def test_one_level_candidate_keeps_receipts_outside_immutable_staged_corpus(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace_root = Path(tmpdir)
+            project_root = workspace_root / "project"
+            project_root.mkdir()
+            corpus_store_root = workspace_root / "corpus-store"
+            corpus_store_root.mkdir()
+            source_drop_root = workspace_root / "source-drop"
+            inbox = source_drop_root / "perplexity" / "inbox"
+            inbox.mkdir(parents=True)
+            (inbox / "export.md").write_text(
+                "# Fresh Export\n\nKeep refresh receipts outside the candidate.\n",
+                encoding="utf-8",
+            )
+            live_root = workspace_root / "perplexity-history-memory"
+            seed_valid_corpus(live_root)
+            upsert_corpus(
+                project_root,
+                live_root,
+                corpus_id="perplexity-history-memory",
+                name="Perplexity History Memory",
+                make_default=True,
+            )
+            register_corpus_store(project_root, corpus_store_root)
+            set_source_policy(
+                project_root,
+                "perplexity",
+                primary_root=live_root,
+                primary_corpus_id="perplexity-history-memory",
+                decision="manual",
+            )
+            candidate_root = corpus_store_root / "candidate-corpus"
+            original_stage = provider_refresh_module.stage_corpus_candidate
+            staged_snapshot: dict[str, dict[str, bytes]] = {}
+
+            def capture_staged_candidate(*args: object, **kwargs: object) -> dict[str, object]:
+                result = original_stage(*args, **kwargs)
+                staged_snapshot["files"] = tree_snapshot(candidate_root)
+                return result
+
+            with patch.object(
+                provider_refresh_module,
+                "stage_corpus_candidate",
+                side_effect=capture_staged_candidate,
+            ):
+                payload = refresh_provider_corpus(
+                    project_root=project_root,
+                    provider="perplexity",
+                    source_drop_root=source_drop_root,
+                    corpus_store_root=corpus_store_root,
+                    candidate_root=candidate_root,
+                )
+
+            refresh_json_path = Path(payload["refresh_json_path"])
+            refresh_markdown_path = Path(payload["refresh_markdown_path"])
+            expected_receipt_root = (
+                corpus_store_root / "provider-refresh" / "perplexity" / payload["run_id"]
+            )
+            validation = validate_json_file("provider-refresh", refresh_json_path)
+
+            self.assertEqual(Path(payload["candidate_root"]), candidate_root.resolve())
+            self.assertEqual(refresh_json_path.parent, expected_receipt_root.resolve())
+            self.assertEqual(refresh_markdown_path.parent, expected_receipt_root.resolve())
+            self.assertFalse(refresh_json_path.is_relative_to(candidate_root.resolve()))
+            self.assertFalse(refresh_markdown_path.is_relative_to(candidate_root.resolve()))
+            self.assertFalse((corpus_store_root / "refresh.json").exists())
+            self.assertFalse((candidate_root / "refresh.json").exists())
+            self.assertEqual(tree_snapshot(candidate_root), staged_snapshot["files"])
+            self.assertTrue(validation["valid"], validation["errors"])
+
     def test_refresh_provider_corpus_stages_candidate_without_mutating_live_registry(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace_root = Path(tmpdir)

--- a/tests/test_provider_refresh.py
+++ b/tests/test_provider_refresh.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+from conversation_corpus_engine.corpus_store import register_corpus_store
 from conversation_corpus_engine.federation import list_registered_corpora, upsert_corpus
 from conversation_corpus_engine.provider_refresh import refresh_provider_corpus
 from conversation_corpus_engine.source_policy import load_source_policy, set_source_policy
@@ -58,6 +59,9 @@ class ProviderRefreshTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace_root = Path(tmpdir)
             project_root = workspace_root / "project"
+            project_root.mkdir()
+            corpus_store_root = workspace_root / "corpus-store"
+            corpus_store_root.mkdir()
             source_drop_root = workspace_root / "source-drop"
             inbox = source_drop_root / "perplexity" / "inbox"
             inbox.mkdir(parents=True, exist_ok=True)
@@ -75,6 +79,7 @@ class ProviderRefreshTests(unittest.TestCase):
                 name="Perplexity History Memory",
                 make_default=True,
             )
+            register_corpus_store(project_root, corpus_store_root)
             set_source_policy(
                 project_root,
                 "perplexity",
@@ -88,6 +93,7 @@ class ProviderRefreshTests(unittest.TestCase):
                 project_root=project_root,
                 provider="perplexity",
                 source_drop_root=source_drop_root,
+                corpus_store_root=corpus_store_root,
                 note="Stage a refreshed Perplexity corpus.",
             )
 
@@ -96,6 +102,11 @@ class ProviderRefreshTests(unittest.TestCase):
 
             self.assertEqual(payload["candidate"]["status"], "staged")
             self.assertTrue(Path(payload["candidate_root"]).exists())
+            self.assertTrue(
+                Path(payload["candidate_root"])
+                .resolve()
+                .is_relative_to((corpus_store_root / "provider-refresh" / "perplexity").resolve())
+            )
             self.assertTrue(payload["evaluation"]["ran"])
             self.assertTrue(Path(payload["evaluation"]["outputs"]["scorecard_md"]).exists())
             self.assertEqual(str(Path(registry[0]["root"]).resolve()), str(live_root.resolve()))
@@ -106,6 +117,9 @@ class ProviderRefreshTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace_root = Path(tmpdir)
             project_root = workspace_root / "project"
+            project_root.mkdir()
+            corpus_store_root = workspace_root / "corpus-store"
+            corpus_store_root.mkdir()
             source_drop_root = workspace_root / "source-drop"
             inbox = source_drop_root / "perplexity" / "inbox"
             inbox.mkdir(parents=True, exist_ok=True)
@@ -123,6 +137,7 @@ class ProviderRefreshTests(unittest.TestCase):
                 name="Perplexity History Memory",
                 make_default=True,
             )
+            register_corpus_store(project_root, corpus_store_root)
             set_source_policy(
                 project_root,
                 "perplexity",
@@ -136,6 +151,7 @@ class ProviderRefreshTests(unittest.TestCase):
                 project_root=project_root,
                 provider="perplexity",
                 source_drop_root=source_drop_root,
+                corpus_store_root=corpus_store_root,
                 promote=True,
                 note="Promote the refreshed Perplexity corpus.",
             )

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -9,6 +9,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from conversation_corpus_engine.corpus_candidates import stage_corpus_candidate
+from conversation_corpus_engine.corpus_store import register_corpus_store
 from conversation_corpus_engine.federation import upsert_corpus
 from conversation_corpus_engine.governance_policy import (
     load_or_create_promotion_policy,
@@ -182,6 +183,7 @@ class SchemaValidationTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace_root = Path(tmpdir)
             project_root = workspace_root / "project"
+            project_root.mkdir()
             primary_root = workspace_root / "gemini-history-memory"
             fallback_root = workspace_root / "gemini-archive-memory"
             primary_root.mkdir(parents=True, exist_ok=True)
@@ -276,6 +278,9 @@ class SchemaValidationTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace_root = Path(tmpdir)
             project_root = workspace_root / "project"
+            project_root.mkdir()
+            corpus_store_root = workspace_root / "corpus-store"
+            corpus_store_root.mkdir()
             live_source = workspace_root / "live-source"
             live_root = workspace_root / "perplexity-history-memory"
             source_drop_root = workspace_root / "source-drop"
@@ -306,6 +311,7 @@ class SchemaValidationTests(unittest.TestCase):
                 name="Perplexity History Memory",
                 make_default=True,
             )
+            register_corpus_store(project_root, corpus_store_root)
             set_source_policy(
                 project_root,
                 "perplexity",
@@ -319,6 +325,7 @@ class SchemaValidationTests(unittest.TestCase):
                 project_root=project_root,
                 provider="perplexity",
                 source_drop_root=source_drop_root,
+                corpus_store_root=corpus_store_root,
                 note="Stage a refreshed Perplexity corpus.",
             )
             result = validate_json_file("provider-refresh", Path(payload["refresh_json_path"]))

--- a/tests/test_surface_exports.py
+++ b/tests/test_surface_exports.py
@@ -38,11 +38,16 @@ def write_markdown_sources(root: Path, files: dict[str, str]) -> None:
         path.write_text(content, encoding="utf-8")
 
 
-def seed_surface_project(project_root: Path, source_drop_root: Path) -> None:
+def seed_surface_project(
+    project_root: Path,
+    source_drop_root: Path,
+    *,
+    corpus_store_root: Path | None = None,
+) -> None:
     workspace_root = project_root.parent
     live_source = workspace_root / "perplexity-live-source"
     candidate_source = workspace_root / "perplexity-candidate-source"
-    live_root = workspace_root / "perplexity-history-memory"
+    live_root = (corpus_store_root or workspace_root) / "perplexity-history-memory"
     candidate_root = workspace_root / "perplexity-history-memory-candidate"
 
     write_markdown_sources(
@@ -112,9 +117,13 @@ class SurfaceExportsTests(unittest.TestCase):
             workspace_root = Path(tmpdir)
             project_root = workspace_root / "project"
             source_drop_root = workspace_root / "source-drop"
-            seed_surface_project(project_root, source_drop_root)
             corpus_store_root = workspace_root / "private-corpus-store"
             corpus_store_root.mkdir()
+            seed_surface_project(
+                project_root,
+                source_drop_root,
+                corpus_store_root=corpus_store_root,
+            )
             register_corpus_store(project_root, corpus_store_root)
 
             manifest = build_surface_manifest(
@@ -176,6 +185,14 @@ class SurfaceExportsTests(unittest.TestCase):
             self.assertEqual(context["summary"]["provider_count"], 8)
             self.assertNotIn(str(corpus_store_root.resolve()), json.dumps(manifest))
             self.assertNotIn(str(corpus_store_root.resolve()), json.dumps(context))
+            self.assertEqual(
+                manifest["registry"]["corpora"][0]["root"],
+                "${CCE_CORPUS_STORE_ROOT}/perplexity-history-memory",
+            )
+            self.assertEqual(
+                context["registry"]["corpora"][0]["root"],
+                "${CCE_CORPUS_STORE_ROOT}/perplexity-history-memory",
+            )
             self.assertTrue(bundle["summary"]["valid"])
             self.assertTrue(manifest_result["valid"], manifest_result["errors"])
             self.assertTrue(context_result["valid"], context_result["errors"])

--- a/tests/test_surface_exports.py
+++ b/tests/test_surface_exports.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 import tempfile
 import unittest
@@ -8,6 +9,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from conversation_corpus_engine.corpus_candidates import stage_corpus_candidate
+from conversation_corpus_engine.corpus_store import register_corpus_store
 from conversation_corpus_engine.federation import build_federation, upsert_corpus
 from conversation_corpus_engine.governance_candidates import stage_policy_candidate
 from conversation_corpus_engine.governance_replay import (
@@ -111,6 +113,9 @@ class SurfaceExportsTests(unittest.TestCase):
             project_root = workspace_root / "project"
             source_drop_root = workspace_root / "source-drop"
             seed_surface_project(project_root, source_drop_root)
+            corpus_store_root = workspace_root / "private-corpus-store"
+            corpus_store_root.mkdir()
+            register_corpus_store(project_root, corpus_store_root)
 
             manifest = build_surface_manifest(
                 project_root,
@@ -169,6 +174,8 @@ class SurfaceExportsTests(unittest.TestCase):
             )
             self.assertEqual(context["summary"]["active_corpus_count"], 1)
             self.assertEqual(context["summary"]["provider_count"], 8)
+            self.assertNotIn(str(corpus_store_root.resolve()), json.dumps(manifest))
+            self.assertNotIn(str(corpus_store_root.resolve()), json.dumps(context))
             self.assertTrue(bundle["summary"]["valid"])
             self.assertTrue(manifest_result["valid"], manifest_result["errors"])
             self.assertTrue(context_result["valid"], context_result["errors"])

--- a/tests/test_surface_exports.py
+++ b/tests/test_surface_exports.py
@@ -22,10 +22,13 @@ from conversation_corpus_engine.import_markdown_document_corpus import (
 from conversation_corpus_engine.schema_validation import validate_json_file, validate_payload
 from conversation_corpus_engine.source_policy import set_source_policy
 from conversation_corpus_engine.surface_exports import (
+    CORPUS_STORE_ROOT_PLACEHOLDER,
+    HISTORICAL_CORPUS_ROOT_PLACEHOLDER,
     build_mcp_context_payload,
     build_surface_manifest,
     export_surface_bundle,
     mcp_context_json_path,
+    redact_corpus_store_paths,
     surface_bundle_json_path,
     surface_manifest_json_path,
 )
@@ -112,6 +115,71 @@ def seed_surface_project(
 
 
 class SurfaceExportsTests(unittest.TestCase):
+    def test_redaction_is_boundary_aware_and_classifies_rotated_corpus_roots(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace_root = Path(tmpdir).resolve()
+            active_store = workspace_root / "active corpus store"
+            active_corpus = active_store / "perplexity history"
+            sibling_prefix = Path(f"{active_store}house") / "public"
+            rotated_corpus = workspace_root / "rotated corpus store" / "perplexity history"
+            unrelated_root = workspace_root / "unrelated root"
+            registry = {
+                "corpus_store": {
+                    "status": "active",
+                    "root": str(active_store),
+                },
+                "corpora": [],
+            }
+            payload = {
+                "registry": {
+                    "corpora": [
+                        {
+                            "corpus_id": "perplexity-history-memory",
+                            "root": str(rotated_corpus),
+                        }
+                    ]
+                },
+                "providers": [
+                    {
+                        "selected_targets": [{"root": str(active_corpus)}],
+                        "source_policy": {"primary_root": str(rotated_corpus)},
+                        "next_command": (
+                            "cce provider bootstrap-eval "
+                            f"--target-root='{active_corpus}' "
+                            f"--legacy-root={rotated_corpus}"
+                        ),
+                    }
+                ],
+                "unrelated": {
+                    "root": str(unrelated_root),
+                    "sibling": str(sibling_prefix),
+                },
+            }
+
+            redacted = redact_corpus_store_paths(payload, registry)
+            serialized = json.dumps(redacted)
+
+            self.assertEqual(
+                redacted["providers"][0]["selected_targets"][0]["root"],
+                f"{CORPUS_STORE_ROOT_PLACEHOLDER}/perplexity history",
+            )
+            self.assertIn(
+                f"--target-root='{CORPUS_STORE_ROOT_PLACEHOLDER}/perplexity history'",
+                redacted["providers"][0]["next_command"],
+            )
+            self.assertIn(
+                f"--legacy-root={HISTORICAL_CORPUS_ROOT_PLACEHOLDER}",
+                redacted["providers"][0]["next_command"],
+            )
+            self.assertEqual(
+                redacted["registry"]["corpora"][0]["root"],
+                HISTORICAL_CORPUS_ROOT_PLACEHOLDER,
+            )
+            self.assertEqual(redacted["unrelated"]["root"], str(unrelated_root))
+            self.assertEqual(redacted["unrelated"]["sibling"], str(sibling_prefix))
+            self.assertNotIn(str(active_corpus), serialized)
+            self.assertNotIn(str(rotated_corpus), serialized)
+
     def test_exported_surface_artifacts_validate_against_published_schemas(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace_root = Path(tmpdir)


### PR DESCRIPTION
## Summary
- Add `cce corpus-store register --root ... --project-root ...` and persist one active `corpus_store` object in federation registry v2.
- Require `--corpus-store-root` or `CCE_CORPUS_STORE_ROOT` for corpus-destination writes, with CLI precedence and no implicit fallback.
- Fail closed before import, refresh, evaluation-bootstrap, or evaluation writes unless the configured root exactly matches the active registration and the destination passes custody, containment, overlap, symlink, nested-repository, and Git-visibility checks.
- Place provider imports at `<store>/<corpus-id>` and refresh candidates at `<store>/provider-refresh/<provider>/<run-id>/candidate-corpus` by default; explicit one-level candidates remain valid and receipts stay outside the staged corpus.
- Redact active store paths as `${CCE_CORPUS_STORE_ROOT}` and classified rotated corpus paths with an opaque historical marker across outward surfaces.
- Keep readiness and generated manual-evaluation commands shell-safe and executable under the active custody contract, while directing legacy out-of-store targets to migrate or re-import.

## Why
Corpus payload writers previously defaulted beside source-drop or under project state and could create output before a durable private-custody boundary was proven. This PR establishes the bounded PR A guardrail required before corpus migration or sharded storage work begins.

## Validation
- Exact remote head: `6701377e161b8c0042f18655b6b2716c2158d29b`.
- Hosted CI run `30022485076`: Python 3.11, 3.12, and 3.13 test/lint/format jobs passed; `schema-check` passed.
- Hosted CodeQL run `30022481588`: actions and Python analyses passed.
- 107 affected local tests passed; repository-wide Ruff lint and format checks passed; `git diff --check` passed.
- All nine review threads have exact-head receipts and are resolved.
- Regression coverage includes zero-write denial, configuration precedence, Git visibility, tracked content, ignore negation, containment, overlap, symlink traversal, nested-clone replay, singular registry replacement, store-backed bootstrap selection, path-boundary and rotated-root redaction, shell-quoted guide commands, in/out-of-store readiness, one-level refresh candidates, immutable candidate staging, receipt placement, schema validity, and outward-surface validation.

## Scope
This is PR A only. Sharding, hashing, corpus migration, Domus deployment, cleanup, issue #36 closure, and draft PR #62 remain out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added corpus-store registration through the CLI.
  * Added `--corpus-store-root` support for provider import, evaluation bootstrap, refresh, and evaluation runs.
  * Added protected write handling that blocks unsafe paths, symlink traversal, Git-visible content, and unregistered stores.
  * Exported manifests and context now redact private corpus-store paths.

* **Documentation**
  * Updated CLI guidance, refresh examples, layout documentation, and corpus-store safety requirements.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->