### PR TITLE
feat: add sharded corpus collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ cce candidate stage --project-root /path/to/project --candidate-root /path/to/ca
 cce candidate review --project-root /path/to/project --candidate-id latest --decision approve --note "promote candidate"
 cce candidate promote --project-root /path/to/project --candidate-id latest --note "replace live corpus"
 cce candidate rollback --project-root /path/to/project --target previous --note "restore previous live corpus"
+cce migration corpus-v2 --project-root /path/to/project --corpus-store-root /path/to/private-corpus-store --source-root /path/to/legacy-corpus --destination-root /path/to/private-corpus-store/migrated-corpus
+cce migration corpus-v2 --project-root /path/to/project --corpus-store-root /path/to/private-corpus-store --source-root /path/to/legacy-corpus --destination-root /path/to/private-corpus-store/migrated-corpus --write
 cce evaluation run --root /path/to/corpus --project-root /path/to/project --corpus-store-root /path/to/private-corpus-store --seed --json
 cce review queue --project-root /path/to/project
 cce review resolve federated-family-merge-... --decision accepted --note "same family"
@@ -105,6 +107,18 @@ implicit fallback. A store must already exist, must not traverse symlinks or con
 Git repositories, and must either live outside Git or be wholly ignored and untracked.
 Provider imports default to `<store>/<corpus-id>`, while refresh candidates default to
 `<store>/provider-refresh/<provider>/<run-id>/candidate-corpus`.
+
+Corpus writers publish `conversation-corpus-engine.v2` collections as immutable
+`cce.sharded_collection.v1` generations. A logical collection such as
+`corpus/threads-index.json` is stored under `corpus/threads-index.collection/`, with an
+atomically replaced `CURRENT` pointer, a verified manifest, and SHA-256-prefix JSONL
+shards capped at 8 MiB and 1,000 records. Readers prefer v2 and read legacy v1 JSON only
+when no v2 storage directory exists; malformed v2 state fails closed.
+
+`cce migration corpus-v2` is read-only unless `--write` is supplied. The write mode
+requires an authorized destination beneath the exactly registered store, preserves the
+v1 source, converts copied `source/conversations.json` data to a sharded collection, and
+is deterministic on rerun.
 
 ## MCP Tools
 
@@ -123,6 +137,8 @@ currently exposes:
 - `src/conversation_corpus_engine/federated_canon.py` — federated review state and canon builders
 - `src/conversation_corpus_engine/federation.py` — corpus registry and federation build/query logic
 - `src/conversation_corpus_engine/corpus_store.py` — private corpus-store registration and write authorization
+- `src/conversation_corpus_engine/sharded_collection.py` — immutable v2 collection publication, validation, and v1-compatible reads
+- `src/conversation_corpus_engine/migration.py` — read-only planning and authorized v1-to-v2 corpus migration
 - `src/conversation_corpus_engine/import_markdown_document_corpus.py` — generic markdown corpus materialization
 - `src/conversation_corpus_engine/import_document_export_corpus.py` — document-style provider export import
 - `src/conversation_corpus_engine/import_claude_export_corpus.py` — Claude bundle import

--- a/src/conversation_corpus_engine/answering.py
+++ b/src/conversation_corpus_engine/answering.py
@@ -8,6 +8,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from .sharded_collection import load_corpus_collection
+
 TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9_-]+")
 STOP_WORDS = {
     "a",
@@ -135,18 +137,25 @@ def build_documents(root: Path) -> dict[str, Any]:
     pair_docs: list[dict[str, Any]] = []
     ledger_docs: list[dict[str, Any]] = []
 
-    threads_index = load_json(root / "corpus" / "threads-index.json", default=[]) or []
-    semantic_index = load_json(
-        root / "corpus" / "semantic-v3-index.json", default={"threads": []}
-    ) or {"threads": []}
-    pairs_index = load_json(root / "corpus" / "pairs-index.json", default=[]) or []
-    doctrine_briefs = load_json(root / "corpus" / "doctrine-briefs.json", default=[]) or []
-    family_dossiers = load_json(root / "corpus" / "family-dossiers.json", default=[]) or []
-    action_ledger = load_json(root / "corpus" / "action-ledger.json", default=[]) or []
-    unresolved_ledger = load_json(root / "corpus" / "unresolved-ledger.json", default=[]) or []
-    doctrine_timeline = load_json(root / "corpus" / "doctrine-timeline.json", default=[]) or []
-    canonical_entities = load_json(root / "corpus" / "canonical-entities.json", default=[]) or []
-    entity_aliases = load_json(root / "corpus" / "entity-aliases.json", default=[]) or []
+    corpus_dir = root / "corpus"
+    threads_index = load_corpus_collection(corpus_dir / "threads-index.json", default=[]) or []
+    semantic_index = {
+        "threads": load_corpus_collection(corpus_dir / "semantic-v3-index.json", default=[]) or []
+    }
+    pairs_index = load_corpus_collection(corpus_dir / "pairs-index.json", default=[]) or []
+    doctrine_briefs = load_corpus_collection(corpus_dir / "doctrine-briefs.json", default=[]) or []
+    family_dossiers = load_corpus_collection(corpus_dir / "family-dossiers.json", default=[]) or []
+    action_ledger = load_corpus_collection(corpus_dir / "action-ledger.json", default=[]) or []
+    unresolved_ledger = (
+        load_corpus_collection(corpus_dir / "unresolved-ledger.json", default=[]) or []
+    )
+    doctrine_timeline = (
+        load_corpus_collection(corpus_dir / "doctrine-timeline.json", default=[]) or []
+    )
+    canonical_entities = (
+        load_corpus_collection(corpus_dir / "canonical-entities.json", default=[]) or []
+    )
+    entity_aliases = load_corpus_collection(corpus_dir / "entity-aliases.json", default=[]) or []
 
     thread_family_map: dict[str, list[str]] = {}
     thread_title_map: dict[str, str] = {}

--- a/src/conversation_corpus_engine/cli.py
+++ b/src/conversation_corpus_engine/cli.py
@@ -40,7 +40,7 @@ from .governance_candidates import (
 )
 from .governance_policy import load_or_create_promotion_policy
 from .governance_replay import build_policy_replay_payload, write_policy_replay_artifacts
-from .migration import seed_registry_from_staging
+from .migration import migrate_corpus_v2, seed_registry_from_staging
 from .paths import default_project_root
 from .persona_extract import extract_persona_lexicon, write_persona_extract_artifacts
 from .provider_catalog import default_source_drop_root
@@ -177,6 +177,16 @@ def build_parser() -> argparse.ArgumentParser:
     migration_review_ids.add_argument("--project-root", type=Path, default=default_project_root())
     migration_review_ids.add_argument("--dry-run", action="store_true")
     migration_review_ids.add_argument("--json", action="store_true")
+
+    migration_corpus_v2 = migration_sub.add_parser(
+        "corpus-v2", help="Plan or write an authorized v1-to-v2 corpus migration"
+    )
+    migration_corpus_v2.add_argument("--source-root", type=Path, required=True)
+    migration_corpus_v2.add_argument("--destination-root", type=Path, required=True)
+    migration_corpus_v2.add_argument("--project-root", type=Path, default=default_project_root())
+    migration_corpus_v2.add_argument("--corpus-store-root", type=Path)
+    migration_corpus_v2.add_argument("--write", action="store_true")
+    migration_corpus_v2.add_argument("--json", action="store_true")
 
     provider = subparsers.add_parser("provider", help="Inspect provider intake and readiness")
     provider_sub = provider.add_subparsers(dest="action", required=True)
@@ -796,6 +806,24 @@ def main() -> None:
             print(f"  Decisions migrated: {stats.get('decisions_migrated', 0)}")
             print(f"  Unchanged:          {stats.get('unchanged', 0)}")
             print(f"  Unique mappings:    {result.get('id_count', 0)}")
+        return
+
+    if args.group == "migration" and args.action == "corpus-v2":
+        result = migrate_corpus_v2(
+            project_root=args.project_root,
+            source_root=args.source_root,
+            destination_root=args.destination_root,
+            corpus_store_root=args.corpus_store_root,
+            write=args.write,
+        )
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(
+                f"Corpus v2 migration ({result['mode']}): {result['collection_count']} collections"
+            )
+            print(f"  Source:      {result['source_root']}")
+            print(f"  Destination: {result['destination_root']}")
         return
 
     if args.group == "provider" and args.action == "discover":

--- a/src/conversation_corpus_engine/corpus_diff.py
+++ b/src/conversation_corpus_engine/corpus_diff.py
@@ -18,11 +18,12 @@ def candidate_entry_for_root(
     target_corpus_id: str,
     target_name: str,
 ) -> dict[str, Any]:
+    validation = validate_corpus_root(candidate_root)
     return {
         "corpus_id": f"{target_corpus_id}-candidate",
         "name": f"{target_name} Candidate",
         "root": str(candidate_root.resolve()),
-        "contract": FEDERATION_CONTRACT,
+        "contract": validation.get("contract_name") or FEDERATION_CONTRACT,
         "status": "candidate",
         "default": False,
     }

--- a/src/conversation_corpus_engine/corpus_store.py
+++ b/src/conversation_corpus_engine/corpus_store.py
@@ -322,8 +322,14 @@ def authorize_additional_corpus_path(
     authorization: CorpusWriteAuthorization,
     destination: Path,
 ) -> CorpusWriteAuthorization:
-    return authorize_corpus_write(
+    resolved_destination = _validate_destination(
+        authorization.store_root,
+        destination,
+        source_roots=(),
+        live_roots=(),
+    )
+    return CorpusWriteAuthorization(
         project_root=authorization.project_root,
-        corpus_store_root=authorization.store_root,
-        destination=destination,
+        store_root=authorization.store_root,
+        destination=resolved_destination,
     )

--- a/src/conversation_corpus_engine/evaluation.py
+++ b/src/conversation_corpus_engine/evaluation.py
@@ -22,6 +22,7 @@ from .corpus_store import (
     authorize_corpus_write,
 )
 from .paths import default_project_root
+from .sharded_collection import load_corpus_collection
 
 DEFAULT_ROOT = Path.cwd()
 DETECTOR_KEYS = (
@@ -248,10 +249,13 @@ def seed_gold(root: Path) -> dict[str, Path]:
     fixtures_manual_dir.mkdir(parents=True, exist_ok=True)
 
     canonical_decisions = load_json(root / "state" / "canonical-decisions.json", default={}) or {}
-    canonical_families = load_json(root / "corpus" / "canonical-families.json", default=[]) or []
-    doctrine_briefs = load_json(root / "corpus" / "doctrine-briefs.json", default=[]) or []
-    family_dossiers = load_json(root / "corpus" / "family-dossiers.json", default=[]) or []
-    pairs_index = load_json(root / "corpus" / "pairs-index.json", default=[]) or []
+    corpus_dir = root / "corpus"
+    canonical_families = (
+        load_corpus_collection(corpus_dir / "canonical-families.json", default=[]) or []
+    )
+    doctrine_briefs = load_corpus_collection(corpus_dir / "doctrine-briefs.json", default=[]) or []
+    family_dossiers = load_corpus_collection(corpus_dir / "family-dossiers.json", default=[]) or []
+    pairs_index = load_corpus_collection(corpus_dir / "pairs-index.json", default=[]) or []
 
     detectors_payload = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -458,7 +462,9 @@ def evaluate_current_corpus(root: Path) -> dict[str, Any]:
     answer_payload, answer_source, answer_path = load_preferred_fixture(root, "answers")
 
     canonical_decisions = load_json(root / "state" / "canonical-decisions.json", default={}) or {}
-    canonical_families = load_json(root / "corpus" / "canonical-families.json", default=[]) or []
+    canonical_families = (
+        load_corpus_collection(root / "corpus" / "canonical-families.json", default=[]) or []
+    )
 
     # Pre-build the corpus document index once — avoids rebuilding from disk per fixture.
     corpus = build_documents(root)

--- a/src/conversation_corpus_engine/federated_canon.py
+++ b/src/conversation_corpus_engine/federated_canon.py
@@ -8,9 +8,10 @@ from pathlib import Path
 from typing import Any
 
 from .answering import load_json, slugify, tokenize, write_json, write_markdown
+from .sharded_collection import collection_storage_path, write_corpus_collection
 
-FEDERATION_CONTRACT = "conversation-corpus-engine-v1"
-FEDERATION_CONTRACT_VERSION = 1
+FEDERATION_CONTRACT = "conversation-corpus-engine.v2"
+FEDERATION_CONTRACT_VERSION = 2
 FEDERATED_REVIEW_TYPES = {
     "entity-alias": ("accepted_entity_aliases", "rejected_entity_aliases"),
     "family-merge": ("accepted_family_merges", "rejected_family_merges"),
@@ -31,6 +32,13 @@ DEFAULT_FEDERATED_DECISIONS = {
     "rejected_contradictions": [],
 }
 CORE_CONTRACT_FILES = (
+    "corpus/threads-index.collection",
+    "corpus/semantic-v3-index.collection",
+    "corpus/pairs-index.collection",
+    "corpus/doctrine-briefs.collection",
+    "corpus/family-dossiers.collection",
+)
+LEGACY_CORE_CONTRACT_FILES = (
     "corpus/threads-index.json",
     "corpus/semantic-v3-index.json",
     "corpus/pairs-index.json",
@@ -903,15 +911,21 @@ def ensure_corpus_contract_manifest(
 ) -> dict[str, Any]:
     path = corpus_root / "corpus" / "contract.json"
     payload = load_json(path, default={}) or {}
+    existing_contract_name = payload.get("contract_name")
+    default_required_files = (
+        LEGACY_CORE_CONTRACT_FILES
+        if existing_contract_name == "conversation-corpus-engine-v1"
+        else CORE_CONTRACT_FILES
+    )
     payload.update(
         {
-            "contract_name": FEDERATION_CONTRACT,
-            "contract_version": FEDERATION_CONTRACT_VERSION,
+            "contract_name": existing_contract_name or FEDERATION_CONTRACT,
+            "contract_version": payload.get("contract_version") or FEDERATION_CONTRACT_VERSION,
             "adapter_type": payload.get("adapter_type") or adapter_type,
             "corpus_id": payload.get("corpus_id") or corpus_id,
             "name": payload.get("name") or name,
             "generated_at": now_iso(),
-            "required_files": list(CORE_CONTRACT_FILES),
+            "required_files": payload.get("required_files") or list(default_required_files),
             "counts": {
                 "threads": summary.get("thread_count", 0),
                 "families": summary.get("family_count", 0),
@@ -1044,14 +1058,18 @@ def build_federated_canon(project_root: Path, surfaces: list[dict[str, Any]]) ->
 
     fed_dir = project_root / "federation"
     fed_dir.mkdir(parents=True, exist_ok=True)
-    write_json(fed_dir / "canonical-entities.json", canonical_entities)
-    write_json(fed_dir / "canonical-families.json", canonical_families)
-    write_json(fed_dir / "canonical-actions.json", canonical_actions)
-    write_json(fed_dir / "canonical-unresolved.json", canonical_unresolved)
-    write_json(fed_dir / "doctrine-briefs.json", doctrine_briefs)
-    write_json(fed_dir / "entity-dossiers.json", entity_dossiers)
-    write_json(fed_dir / "project-dossiers.json", project_dossiers)
-    write_json(fed_dir / "lineage-map.json", lineage_map)
+    collections = {
+        "canonical-entities.json": canonical_entities,
+        "canonical-families.json": canonical_families,
+        "canonical-actions.json": canonical_actions,
+        "canonical-unresolved.json": canonical_unresolved,
+        "doctrine-briefs.json": doctrine_briefs,
+        "entity-dossiers.json": entity_dossiers,
+        "project-dossiers.json": project_dossiers,
+        "lineage-map.json": lineage_map,
+    }
+    for filename, records in collections.items():
+        write_corpus_collection(fed_dir / filename, records)
     write_json(fed_dir / "conflict-report.json", conflict_report)
     write_markdown(fed_dir / "overlap-report.md", overlap_report)
     write_markdown(
@@ -1067,14 +1085,20 @@ def build_federated_canon(project_root: Path, surfaces: list[dict[str, Any]]) ->
         ),
     )
     return {
-        "canonical_entities_path": str(fed_dir / "canonical-entities.json"),
-        "canonical_families_path": str(fed_dir / "canonical-families.json"),
-        "canonical_actions_path": str(fed_dir / "canonical-actions.json"),
-        "canonical_unresolved_path": str(fed_dir / "canonical-unresolved.json"),
-        "doctrine_briefs_path": str(fed_dir / "doctrine-briefs.json"),
-        "entity_dossiers_path": str(fed_dir / "entity-dossiers.json"),
-        "project_dossiers_path": str(fed_dir / "project-dossiers.json"),
-        "lineage_map_path": str(fed_dir / "lineage-map.json"),
+        "canonical_entities_path": str(
+            collection_storage_path(fed_dir / "canonical-entities.json")
+        ),
+        "canonical_families_path": str(
+            collection_storage_path(fed_dir / "canonical-families.json")
+        ),
+        "canonical_actions_path": str(collection_storage_path(fed_dir / "canonical-actions.json")),
+        "canonical_unresolved_path": str(
+            collection_storage_path(fed_dir / "canonical-unresolved.json")
+        ),
+        "doctrine_briefs_path": str(collection_storage_path(fed_dir / "doctrine-briefs.json")),
+        "entity_dossiers_path": str(collection_storage_path(fed_dir / "entity-dossiers.json")),
+        "project_dossiers_path": str(collection_storage_path(fed_dir / "project-dossiers.json")),
+        "lineage_map_path": str(collection_storage_path(fed_dir / "lineage-map.json")),
         "conflict_report_path": str(fed_dir / "conflict-report.json"),
         "overlap_report_path": str(fed_dir / "overlap-report.md"),
         "review_queue_path": str(fed_dir / "review-queue.json"),

--- a/src/conversation_corpus_engine/federation.py
+++ b/src/conversation_corpus_engine/federation.py
@@ -21,10 +21,16 @@ from .answering import (
 )
 from .federated_canon import build_federated_canon
 from .paths import default_project_root, resolve_workspace_path
+from .sharded_collection import (
+    collection_exists,
+    collection_storage_path,
+    load_corpus_collection,
+    write_corpus_collection,
+)
 from .source_lifecycle import compute_source_freshness
 
 DEFAULT_PROJECT_ROOT = default_project_root()
-FEDERATION_CONTRACT = "conversation-corpus-engine-v1"
+FEDERATION_CONTRACT = "conversation-corpus-engine.v2"
 REGISTRY_VERSION = 2
 REQUIRED_CONTRACT_FILES = (
     "corpus/threads-index.json",
@@ -58,7 +64,9 @@ def answers_dir(root: Path) -> Path:
 def validate_corpus_root(corpus_root: Path) -> dict[str, Any]:
     corpus_root = resolve_workspace_path(corpus_root)
     missing = [
-        relative for relative in REQUIRED_CONTRACT_FILES if not (corpus_root / relative).exists()
+        relative
+        for relative in REQUIRED_CONTRACT_FILES
+        if not collection_exists(corpus_root / relative)
     ]
     contract_manifest = load_json(corpus_root / "corpus" / "contract.json", default={}) or {}
     return {
@@ -71,11 +79,12 @@ def validate_corpus_root(corpus_root: Path) -> dict[str, Any]:
 
 
 def default_registry_entry(project_root: Path) -> dict[str, Any]:
+    validation = validate_corpus_root(project_root)
     return {
         "corpus_id": "primary-corpus",
         "name": "Primary Corpus",
         "root": str(project_root),
-        "contract": FEDERATION_CONTRACT,
+        "contract": validation.get("contract_name") or FEDERATION_CONTRACT,
         "status": "active",
         "default": True,
         "registered_at": now_iso(),
@@ -149,7 +158,7 @@ def upsert_corpus(
     *,
     corpus_id: str | None = None,
     name: str | None = None,
-    contract: str = FEDERATION_CONTRACT,
+    contract: str | None = None,
     status: str = "active",
     make_default: bool = False,
 ) -> dict[str, Any]:
@@ -160,6 +169,7 @@ def upsert_corpus(
         raise ValueError(f"Corpus root {corpus_root} is missing required contract files: {missing}")
 
     registry = load_registry(project_root)
+    resolved_contract = contract or validation.get("contract_name") or FEDERATION_CONTRACT
     resolved_id = normalize_corpus_id(corpus_id or corpus_root.name)
     existing = next(
         (entry for entry in registry["corpora"] if entry["corpus_id"] == resolved_id), None
@@ -168,14 +178,14 @@ def upsert_corpus(
         entry = existing
         entry["name"] = name or entry.get("name") or corpus_root.name
         entry["root"] = str(corpus_root)
-        entry["contract"] = contract
+        entry["contract"] = resolved_contract
         entry["status"] = status
     else:
         entry = {
             "corpus_id": resolved_id,
             "name": name or corpus_root.name,
             "root": str(corpus_root),
-            "contract": contract,
+            "contract": resolved_contract,
             "status": status,
             "default": False,
             "registered_at": now_iso(),
@@ -204,13 +214,14 @@ def remove_corpus(project_root: Path, corpus_id: str) -> dict[str, Any]:
 
 def load_corpus_surface(entry: dict[str, Any]) -> dict[str, Any]:
     root = resolve_workspace_path(Path(entry["root"]))
-    threads = load_json(root / "corpus" / "threads-index.json", default=[]) or []
-    doctrine_briefs = load_json(root / "corpus" / "doctrine-briefs.json", default=[]) or []
-    family_dossiers = load_json(root / "corpus" / "family-dossiers.json", default=[]) or []
-    families = load_json(root / "corpus" / "canonical-families.json", default=[]) or []
-    actions = load_json(root / "corpus" / "action-ledger.json", default=[]) or []
-    unresolved = load_json(root / "corpus" / "unresolved-ledger.json", default=[]) or []
-    entities = load_json(root / "corpus" / "canonical-entities.json", default=[]) or []
+    corpus_dir = root / "corpus"
+    threads = load_corpus_collection(corpus_dir / "threads-index.json", default=[]) or []
+    doctrine_briefs = load_corpus_collection(corpus_dir / "doctrine-briefs.json", default=[]) or []
+    family_dossiers = load_corpus_collection(corpus_dir / "family-dossiers.json", default=[]) or []
+    families = load_corpus_collection(corpus_dir / "canonical-families.json", default=[]) or []
+    actions = load_corpus_collection(corpus_dir / "action-ledger.json", default=[]) or []
+    unresolved = load_corpus_collection(corpus_dir / "unresolved-ledger.json", default=[]) or []
+    entities = load_corpus_collection(corpus_dir / "canonical-entities.json", default=[]) or []
     contract_manifest = load_json(root / "corpus" / "contract.json", default={}) or {}
     evaluation = load_json(root / "corpus" / "evaluation-summary.json", default={}) or {}
     gates = load_json(root / "corpus" / "regression-gates.json", default={}) or {}
@@ -385,11 +396,15 @@ def build_federation(project_root: Path) -> dict[str, Any]:
     fed_dir = federation_dir(project_root)
     fed_dir.mkdir(parents=True, exist_ok=True)
     write_json(fed_dir / "registry.json", registry)
-    write_json(fed_dir / "corpora-summary.json", corpora_summary)
-    write_json(fed_dir / "families-index.json", families_index)
-    write_json(fed_dir / "actions-index.json", actions_index)
-    write_json(fed_dir / "unresolved-index.json", unresolved_index)
-    write_json(fed_dir / "entities-index.json", entities_index)
+    collections = {
+        "corpora-summary.json": corpora_summary,
+        "families-index.json": families_index,
+        "actions-index.json": actions_index,
+        "unresolved-index.json": unresolved_index,
+        "entities-index.json": entities_index,
+    }
+    for filename, records in collections.items():
+        write_corpus_collection(fed_dir / filename, records)
     write_json(fed_dir / "evaluation-summary.json", evaluation_summary)
     write_markdown(
         federation_report_path(project_root),
@@ -397,11 +412,11 @@ def build_federation(project_root: Path) -> dict[str, Any]:
     )
     return {
         "registry_path": str(fed_dir / "registry.json"),
-        "corpora_summary_path": str(fed_dir / "corpora-summary.json"),
-        "families_index_path": str(fed_dir / "families-index.json"),
-        "actions_index_path": str(fed_dir / "actions-index.json"),
-        "unresolved_index_path": str(fed_dir / "unresolved-index.json"),
-        "entities_index_path": str(fed_dir / "entities-index.json"),
+        "corpora_summary_path": str(collection_storage_path(fed_dir / "corpora-summary.json")),
+        "families_index_path": str(collection_storage_path(fed_dir / "families-index.json")),
+        "actions_index_path": str(collection_storage_path(fed_dir / "actions-index.json")),
+        "unresolved_index_path": str(collection_storage_path(fed_dir / "unresolved-index.json")),
+        "entities_index_path": str(collection_storage_path(fed_dir / "entities-index.json")),
         "evaluation_summary_path": str(fed_dir / "evaluation-summary.json"),
         "summary_markdown_path": str(federation_report_path(project_root)),
         **canon_outputs,
@@ -460,15 +475,17 @@ def render_federation_summary(
 
 def ensure_federation(project_root: Path) -> None:
     fed_dir = federation_dir(project_root)
-    required = (
-        fed_dir / "corpora-summary.json",
-        fed_dir / "families-index.json",
-        fed_dir / "actions-index.json",
-        fed_dir / "unresolved-index.json",
-        fed_dir / "entities-index.json",
-        fed_dir / "evaluation-summary.json",
+    collection_names = (
+        "corpora-summary.json",
+        "families-index.json",
+        "actions-index.json",
+        "unresolved-index.json",
+        "entities-index.json",
     )
-    if not all(path.exists() for path in required):
+    if (
+        not all(collection_exists(fed_dir / name) for name in collection_names)
+        or not (fed_dir / "evaluation-summary.json").exists()
+    ):
         build_federation(project_root)
 
 
@@ -504,7 +521,10 @@ def load_federation_index(project_root: Path, ledger: str) -> Any:
         "evaluation-scorecard",
     }
     default = {} if ledger in dict_ledgers else []
-    return load_json(federation_dir(project_root) / mapping[ledger], default=default) or default
+    logical_path = federation_dir(project_root) / mapping[ledger]
+    if ledger not in dict_ledgers:
+        return load_corpus_collection(logical_path, default=default) or default
+    return load_json(logical_path, default=default) or default
 
 
 def query_federation_index(

--- a/src/conversation_corpus_engine/import_chatgpt_export_corpus.py
+++ b/src/conversation_corpus_engine/import_chatgpt_export_corpus.py
@@ -9,14 +9,27 @@ from collections import Counter
 from datetime import datetime, timezone
 from difflib import SequenceMatcher
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .answering import slugify, tokenize, write_json, write_markdown
+from .sharded_collection import (
+    collection_exists,
+    collection_storage_path,
+    content_hash_key,
+    load_collection,
+    merge_entity_records,
+    merge_ledger_records,
+    write_collection,
+    write_corpus_collection,
+)
 from .source_lifecycle import build_source_snapshot
 
+if TYPE_CHECKING:
+    from .corpus_store import CorpusWriteAuthorization
+
 DEFAULT_OUTPUT_ROOT = Path.cwd() / "chatgpt-history-memory"
-CONTRACT_NAME = "conversation-corpus-engine-v1"
-CONTRACT_VERSION = 1
+CONTRACT_NAME = "conversation-corpus-engine.v2"
+CONTRACT_VERSION = 2
 REQUIRED_BUNDLE_FILES = ("conversations.json", "user.json")
 STOP_WORDS = {
     "a",
@@ -138,6 +151,11 @@ def load_json_file(path: Path, default: Any) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def bundle_file_exists(bundle_root: Path, name: str) -> bool:
+    path = bundle_root / name
+    return collection_exists(path) if name == "conversations.json" else path.exists()
+
+
 def resolve_bundle_root(input_path: Path) -> Path:
     input_path = input_path.resolve()
     if input_path.is_file():
@@ -149,7 +167,7 @@ def resolve_bundle_root(input_path: Path) -> Path:
             )
     else:
         bundle_root = input_path
-    missing = [name for name in REQUIRED_BUNDLE_FILES if not (bundle_root / name).exists()]
+    missing = [name for name in REQUIRED_BUNDLE_FILES if not bundle_file_exists(bundle_root, name)]
     if missing:
         raise FileNotFoundError(
             f"ChatGPT export bundle at {bundle_root} is missing required files: {', '.join(missing)}"
@@ -174,16 +192,16 @@ def discover_bundle_roots(input_path: Path) -> list[Path]:
         raise ValueError(
             f"Expected a ChatGPT export directory or conversations.json file, got {input_path}"
         )
-    if all((input_path / name).exists() for name in REQUIRED_BUNDLE_FILES):
+    if all(bundle_file_exists(input_path, name) for name in REQUIRED_BUNDLE_FILES):
         return [input_path]
     parts = sorted(
         child
         for child in input_path.iterdir()
-        if child.is_dir() and all((child / name).exists() for name in REQUIRED_BUNDLE_FILES)
+        if child.is_dir() and all(bundle_file_exists(child, name) for name in REQUIRED_BUNDLE_FILES)
     )
     if parts:
         return parts
-    missing = [name for name in REQUIRED_BUNDLE_FILES if not (input_path / name).exists()]
+    missing = [name for name in REQUIRED_BUNDLE_FILES if not bundle_file_exists(input_path, name)]
     raise FileNotFoundError(
         f"ChatGPT export bundle at {input_path} is missing required files: "
         f"{', '.join(missing)} (no multi-part subdirectories with valid bundles found either)"
@@ -602,7 +620,11 @@ def detect_near_duplicates(
 
 
 def copy_bundle_files(
-    bundle_root: Path, output_root: Path, *, prefix: str | None = None
+    bundle_root: Path,
+    output_root: Path,
+    *,
+    prefix: str | None = None,
+    authorization: CorpusWriteAuthorization | None = None,
 ) -> list[str]:
     copied: list[str] = []
     source_root = output_root / "source"
@@ -610,11 +632,28 @@ def copy_bundle_files(
         source_root = source_root / prefix
     source_root.mkdir(parents=True, exist_ok=True)
     for path in sorted(bundle_root.rglob("*.json")):
+        if (
+            path == bundle_root / "conversations.json"
+            or collection_storage_path(bundle_root / "conversations.json") in path.parents
+        ):
+            continue
         relative = path.relative_to(bundle_root)
         destination = source_root / relative
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(path, destination)
         copied.append(str(destination))
+    conversations_path = source_root / "conversations.json"
+    write_collection(
+        conversations_path,
+        load_collection(bundle_root / "conversations.json", default=[]),
+        key=lambda record: (
+            str(record.get("conversation_id") or record.get("id"))
+            if isinstance(record, dict) and (record.get("conversation_id") or record.get("id"))
+            else content_hash_key(record)
+        ),
+        authorization=authorization,
+    )
+    copied.append(str(collection_storage_path(conversations_path)))
     return copied
 
 
@@ -625,6 +664,7 @@ def import_chatgpt_export_corpus(
     corpus_id: str | None = None,
     name: str | None = None,
     throttle: float = 0.0,
+    authorization: CorpusWriteAuthorization | None = None,
 ) -> dict[str, Any]:
     bundle_roots = discover_bundle_roots(input_path)
     bundle_root = bundle_roots[0]  # primary — used for source_snapshot, manifest, briefs
@@ -634,7 +674,10 @@ def import_chatgpt_export_corpus(
     seen_conversation_ids: set[str] = set()
     duplicate_skipped_count = 0
     for part_root in bundle_roots:
-        part_conversations = load_json_file(part_root / "conversations.json", default=[])
+        part_conversations = load_collection(
+            part_root / "conversations.json",
+            default=[],
+        )
         for conv in part_conversations:
             cid = conv.get("conversation_id")
             if cid and cid in seen_conversation_ids:
@@ -651,7 +694,14 @@ def import_chatgpt_export_corpus(
     copied_sources: list[str] = []
     for part_root in bundle_roots:
         part_prefix = part_root.name if is_multi_part else None
-        copied_sources.extend(copy_bundle_files(part_root, output_root, prefix=part_prefix))
+        copied_sources.extend(
+            copy_bundle_files(
+                part_root,
+                output_root,
+                prefix=part_prefix,
+                authorization=authorization,
+            )
+        )
 
     threads: list[dict[str, Any]] = []
     semantic_threads: list[dict[str, Any]] = []
@@ -763,7 +813,7 @@ def import_chatgpt_export_corpus(
                 "action_count": len(action_items),
                 "unresolved_question_count": len(unresolved_items),
                 "audit_flags": audit.get("quality_flags", []),
-                "thread_path": str(output_root / "source" / "conversations.json"),
+                "thread_path": str(output_root / "source" / "conversations.collection"),
                 "family_ids": [family_id],
                 "update_time_iso": update_time,
             },
@@ -846,7 +896,17 @@ def import_chatgpt_export_corpus(
             },
         )
 
-    entities = list(entity_map.values())
+    actions = merge_ledger_records(
+        actions,
+        key_field="action_key",
+        text_field="canonical_action",
+    )
+    unresolved = merge_ledger_records(
+        unresolved,
+        key_field="question_key",
+        text_field="canonical_question",
+    )
+    entities = merge_entity_records(entity_map.values())
     entity_aliases = [
         {"canonical_label": entity["canonical_label"], "labels": entity.get("aliases", [])}
         for entity in entities
@@ -857,20 +917,32 @@ def import_chatgpt_export_corpus(
 
     corpus_dir = output_root / "corpus"
     source_snapshot = build_source_snapshot(bundle_root, "chatgpt-export", "bundle-json")
-    write_json(corpus_dir / "threads-index.json", threads)
-    write_json(corpus_dir / "semantic-v3-index.json", {"threads": semantic_threads})
-    write_json(corpus_dir / "pairs-index.json", pairs)
-    write_json(corpus_dir / "doctrine-briefs.json", doctrine_briefs)
-    write_json(corpus_dir / "family-dossiers.json", family_dossiers)
-    write_json(corpus_dir / "canonical-families.json", canonical_families)
-    write_json(corpus_dir / "action-ledger.json", actions)
-    write_json(corpus_dir / "unresolved-ledger.json", unresolved)
-    write_json(corpus_dir / "canonical-entities.json", entities)
-    write_json(corpus_dir / "entity-aliases.json", entity_aliases)
-    write_json(corpus_dir / "doctrine-timeline.json", [])
-    write_json(corpus_dir / "import-audit.json", thread_audits)
+    collections = {
+        "threads-index.json": threads,
+        "semantic-v3-index.json": semantic_threads,
+        "pairs-index.json": pairs,
+        "doctrine-briefs.json": doctrine_briefs,
+        "family-dossiers.json": family_dossiers,
+        "canonical-families.json": canonical_families,
+        "action-ledger.json": actions,
+        "unresolved-ledger.json": unresolved,
+        "canonical-entities.json": entities,
+        "entity-aliases.json": entity_aliases,
+        "doctrine-timeline.json": [],
+        "import-audit.json": thread_audits,
+    }
+    for filename, records in collections.items():
+        write_corpus_collection(
+            corpus_dir / filename,
+            records,
+            authorization=authorization,
+        )
     if near_duplicates:
-        write_json(corpus_dir / "near-duplicates.json", near_duplicates)
+        write_corpus_collection(
+            corpus_dir / "near-duplicates.json",
+            near_duplicates,
+            authorization=authorization,
+        )
     write_json(corpus_dir / "source-snapshot.json", source_snapshot)
     write_json(
         corpus_dir / "contract.json",
@@ -882,11 +954,11 @@ def import_chatgpt_export_corpus(
             "name": name or output_root.name,
             "generated_at": now_iso(),
             "required_files": [
-                "corpus/threads-index.json",
-                "corpus/semantic-v3-index.json",
-                "corpus/pairs-index.json",
-                "corpus/doctrine-briefs.json",
-                "corpus/family-dossiers.json",
+                "corpus/threads-index.collection",
+                "corpus/semantic-v3-index.collection",
+                "corpus/pairs-index.collection",
+                "corpus/doctrine-briefs.collection",
+                "corpus/family-dossiers.collection",
             ],
             "counts": {
                 "threads": len(threads),
@@ -929,7 +1001,11 @@ def import_chatgpt_export_corpus(
             "gates": [],
         },
     )
-    write_json(output_root / "import-manifest.json", import_manifest)
+    write_corpus_collection(
+        output_root / "import-manifest.json",
+        import_manifest,
+        authorization=authorization,
+    )
     write_markdown(
         output_root / "README.md",
         "\n".join(
@@ -967,7 +1043,7 @@ def import_chatgpt_export_corpus(
         "empty_conversation_count": empty_conversation_count,
         "near_duplicate_count": len(near_duplicates),
         "flagged_thread_count": sum(1 for a in thread_audits if a.get("quality_flags")),
-        "manifest_path": str(output_root / "import-manifest.json"),
+        "manifest_path": str(collection_storage_path(output_root / "import-manifest.json")),
         "readme_path": str(output_root / "README.md"),
         "bundle_part_count": len(bundle_roots),
         "bundle_part_names": [p.name for p in bundle_roots],

--- a/src/conversation_corpus_engine/import_chatgpt_local_session_corpus.py
+++ b/src/conversation_corpus_engine/import_chatgpt_local_session_corpus.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .answering import load_json, write_json, write_markdown
 from .chatgpt_local_session import (
@@ -23,7 +23,11 @@ from .chatgpt_local_session import (
     scope_preflight_check,
 )
 from .import_chatgpt_export_corpus import import_chatgpt_export_corpus
+from .sharded_collection import content_hash_key, write_collection
 from .source_lifecycle import build_source_snapshot
+
+if TYPE_CHECKING:
+    from .corpus_store import CorpusWriteAuthorization
 
 DEFAULT_OUTPUT_ROOT = Path.cwd() / "chatgpt-local-session-memory"
 DEFAULT_CORPUS_ID = "chatgpt-local-session-memory"
@@ -34,7 +38,15 @@ def write_local_session_bundle(bundle_root: Path, bundle: dict[str, Any]) -> Non
     bundle_root.mkdir(parents=True, exist_ok=True)
     user_payload = bundle.get("user") or {}
     write_json(bundle_root / "user.json", user_payload)
-    write_json(bundle_root / "conversations.json", bundle.get("conversations") or [])
+    write_collection(
+        bundle_root / "conversations.json",
+        bundle.get("conversations") or [],
+        key=lambda record: (
+            str(record.get("conversation_id") or record.get("id"))
+            if isinstance(record, dict) and (record.get("conversation_id") or record.get("id"))
+            else content_hash_key(record)
+        ),
+    )
     write_json(
         bundle_root / "conversation-summaries.json",
         bundle.get("conversation_summaries") or [],
@@ -126,6 +138,7 @@ def import_chatgpt_local_session_corpus(
     limit: int = 100,
     offset: int = 0,
     throttle: float = 0.0,
+    authorization: CorpusWriteAuthorization | None = None,
 ) -> dict[str, Any]:
     cookie_jar = cookie_jar.resolve()
     output_root = output_root.resolve()
@@ -146,7 +159,12 @@ def import_chatgpt_local_session_corpus(
         bundle_root = Path(tmpdir) / "chatgpt-local-bundle"
         write_local_session_bundle(bundle_root, bundle)
         result = import_chatgpt_export_corpus(
-            bundle_root, output_root, corpus_id=corpus_id, name=name, throttle=throttle
+            bundle_root,
+            output_root,
+            corpus_id=corpus_id,
+            name=name,
+            throttle=throttle,
+            authorization=authorization,
         )
         source_root = output_root / "source"
         source_root.mkdir(parents=True, exist_ok=True)

--- a/src/conversation_corpus_engine/import_claude_export_corpus.py
+++ b/src/conversation_corpus_engine/import_claude_export_corpus.py
@@ -9,14 +9,27 @@ from collections import Counter
 from datetime import datetime, timezone
 from difflib import SequenceMatcher
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .answering import slugify, tokenize, write_json, write_markdown
+from .sharded_collection import (
+    collection_exists,
+    collection_storage_path,
+    content_hash_key,
+    load_collection,
+    merge_entity_records,
+    merge_ledger_records,
+    write_collection,
+    write_corpus_collection,
+)
 from .source_lifecycle import build_source_snapshot
 
+if TYPE_CHECKING:
+    from .corpus_store import CorpusWriteAuthorization
+
 DEFAULT_OUTPUT_ROOT = Path.cwd() / "claude-history-memory"
-CONTRACT_NAME = "conversation-corpus-engine-v1"
-CONTRACT_VERSION = 1
+CONTRACT_NAME = "conversation-corpus-engine.v2"
+CONTRACT_VERSION = 2
 REQUIRED_BUNDLE_FILES = ("conversations.json", "users.json")
 STOP_WORDS = {
     "a",
@@ -126,6 +139,11 @@ def load_json_file(path: Path, default: Any) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def bundle_file_exists(bundle_root: Path, name: str) -> bool:
+    path = bundle_root / name
+    return collection_exists(path) if name == "conversations.json" else path.exists()
+
+
 def resolve_bundle_root(input_path: Path) -> Path:
     input_path = input_path.resolve()
     if input_path.is_file():
@@ -137,7 +155,7 @@ def resolve_bundle_root(input_path: Path) -> Path:
             )
     else:
         bundle_root = input_path
-    missing = [name for name in REQUIRED_BUNDLE_FILES if not (bundle_root / name).exists()]
+    missing = [name for name in REQUIRED_BUNDLE_FILES if not bundle_file_exists(bundle_root, name)]
     if missing:
         raise FileNotFoundError(
             f"Claude export bundle at {bundle_root} is missing required files: {', '.join(missing)}"
@@ -163,16 +181,16 @@ def discover_bundle_roots(input_path: Path) -> list[Path]:
         raise ValueError(
             f"Expected a Claude export directory or conversations.json file, got {input_path}"
         )
-    if all((input_path / name).exists() for name in REQUIRED_BUNDLE_FILES):
+    if all(bundle_file_exists(input_path, name) for name in REQUIRED_BUNDLE_FILES):
         return [input_path]
     parts = sorted(
         child
         for child in input_path.iterdir()
-        if child.is_dir() and all((child / name).exists() for name in REQUIRED_BUNDLE_FILES)
+        if child.is_dir() and all(bundle_file_exists(child, name) for name in REQUIRED_BUNDLE_FILES)
     )
     if parts:
         return parts
-    missing = [name for name in REQUIRED_BUNDLE_FILES if not (input_path / name).exists()]
+    missing = [name for name in REQUIRED_BUNDLE_FILES if not bundle_file_exists(input_path, name)]
     raise FileNotFoundError(
         f"Claude export bundle at {input_path} is missing required files: "
         f"{', '.join(missing)} (no multi-part subdirectories with valid bundles found either)"
@@ -604,7 +622,11 @@ def detect_near_duplicates(
 
 
 def copy_bundle_files(
-    bundle_root: Path, output_root: Path, *, prefix: str | None = None
+    bundle_root: Path,
+    output_root: Path,
+    *,
+    prefix: str | None = None,
+    authorization: CorpusWriteAuthorization | None = None,
 ) -> list[str]:
     copied: list[str] = []
     source_root = output_root / "source"
@@ -612,11 +634,28 @@ def copy_bundle_files(
         source_root = source_root / prefix
     source_root.mkdir(parents=True, exist_ok=True)
     for path in sorted(bundle_root.rglob("*.json")):
+        if (
+            path == bundle_root / "conversations.json"
+            or collection_storage_path(bundle_root / "conversations.json") in path.parents
+        ):
+            continue
         relative = path.relative_to(bundle_root)
         destination = source_root / relative
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(path, destination)
         copied.append(str(destination))
+    conversations_path = source_root / "conversations.json"
+    write_collection(
+        conversations_path,
+        load_collection(bundle_root / "conversations.json", default=[]),
+        key=lambda record: (
+            str(record.get("uuid") or record.get("id"))
+            if isinstance(record, dict) and (record.get("uuid") or record.get("id"))
+            else content_hash_key(record)
+        ),
+        authorization=authorization,
+    )
+    copied.append(str(collection_storage_path(conversations_path)))
     return copied
 
 
@@ -627,6 +666,7 @@ def import_claude_export_corpus(
     corpus_id: str | None = None,
     name: str | None = None,
     throttle: float = 0.0,
+    authorization: CorpusWriteAuthorization | None = None,
 ) -> dict[str, Any]:
     bundle_roots = discover_bundle_roots(input_path)
     bundle_root = bundle_roots[0]  # primary — used for source_snapshot, manifest, briefs
@@ -636,7 +676,10 @@ def import_claude_export_corpus(
     seen_conversation_uuids: set[str] = set()
     duplicate_skipped_count = 0
     for part_root in bundle_roots:
-        part_conversations = load_json_file(part_root / "conversations.json", default=[])
+        part_conversations = load_collection(
+            part_root / "conversations.json",
+            default=[],
+        )
         for conv in part_conversations:
             uid = conv.get("uuid")
             if uid and uid in seen_conversation_uuids:
@@ -657,7 +700,14 @@ def import_claude_export_corpus(
     copied_sources: list[str] = []
     for part_root in bundle_roots:
         part_prefix = part_root.name if is_multi_part else None
-        copied_sources.extend(copy_bundle_files(part_root, output_root, prefix=part_prefix))
+        copied_sources.extend(
+            copy_bundle_files(
+                part_root,
+                output_root,
+                prefix=part_prefix,
+                authorization=authorization,
+            )
+        )
 
     threads: list[dict[str, Any]] = []
     semantic_threads: list[dict[str, Any]] = []
@@ -761,7 +811,7 @@ def import_claude_export_corpus(
                 "action_count": len(action_items),
                 "unresolved_question_count": len(unresolved_items),
                 "audit_flags": audit.get("quality_flags", []),
-                "thread_path": str(output_root / "source" / "conversations.json"),
+                "thread_path": str(output_root / "source" / "conversations.collection"),
                 "family_ids": [family_id],
                 "update_time_iso": update_time,
             },
@@ -844,7 +894,17 @@ def import_claude_export_corpus(
             },
         )
 
-    entities = list(entity_map.values())
+    actions = merge_ledger_records(
+        actions,
+        key_field="action_key",
+        text_field="canonical_action",
+    )
+    unresolved = merge_ledger_records(
+        unresolved,
+        key_field="question_key",
+        text_field="canonical_question",
+    )
+    entities = merge_entity_records(entity_map.values())
     entity_aliases = [
         {"canonical_label": entity["canonical_label"], "labels": entity.get("aliases", [])}
         for entity in entities
@@ -854,20 +914,32 @@ def import_claude_export_corpus(
 
     corpus_dir = output_root / "corpus"
     source_snapshot = build_source_snapshot(bundle_root, "claude-export", "bundle-json")
-    write_json(corpus_dir / "threads-index.json", threads)
-    write_json(corpus_dir / "semantic-v3-index.json", {"threads": semantic_threads})
-    write_json(corpus_dir / "pairs-index.json", pairs)
-    write_json(corpus_dir / "doctrine-briefs.json", doctrine_briefs)
-    write_json(corpus_dir / "family-dossiers.json", family_dossiers)
-    write_json(corpus_dir / "canonical-families.json", canonical_families)
-    write_json(corpus_dir / "action-ledger.json", actions)
-    write_json(corpus_dir / "unresolved-ledger.json", unresolved)
-    write_json(corpus_dir / "canonical-entities.json", entities)
-    write_json(corpus_dir / "entity-aliases.json", entity_aliases)
-    write_json(corpus_dir / "doctrine-timeline.json", [])
-    write_json(corpus_dir / "import-audit.json", thread_audits)
+    collections = {
+        "threads-index.json": threads,
+        "semantic-v3-index.json": semantic_threads,
+        "pairs-index.json": pairs,
+        "doctrine-briefs.json": doctrine_briefs,
+        "family-dossiers.json": family_dossiers,
+        "canonical-families.json": canonical_families,
+        "action-ledger.json": actions,
+        "unresolved-ledger.json": unresolved,
+        "canonical-entities.json": entities,
+        "entity-aliases.json": entity_aliases,
+        "doctrine-timeline.json": [],
+        "import-audit.json": thread_audits,
+    }
+    for filename, records in collections.items():
+        write_corpus_collection(
+            corpus_dir / filename,
+            records,
+            authorization=authorization,
+        )
     if near_duplicates:
-        write_json(corpus_dir / "near-duplicates.json", near_duplicates)
+        write_corpus_collection(
+            corpus_dir / "near-duplicates.json",
+            near_duplicates,
+            authorization=authorization,
+        )
     write_json(corpus_dir / "source-snapshot.json", source_snapshot)
     write_json(
         corpus_dir / "contract.json",
@@ -879,11 +951,11 @@ def import_claude_export_corpus(
             "name": name or output_root.name,
             "generated_at": now_iso(),
             "required_files": [
-                "corpus/threads-index.json",
-                "corpus/semantic-v3-index.json",
-                "corpus/pairs-index.json",
-                "corpus/doctrine-briefs.json",
-                "corpus/family-dossiers.json",
+                "corpus/threads-index.collection",
+                "corpus/semantic-v3-index.collection",
+                "corpus/pairs-index.collection",
+                "corpus/doctrine-briefs.collection",
+                "corpus/family-dossiers.collection",
             ],
             "counts": {
                 "threads": len(threads),
@@ -928,7 +1000,11 @@ def import_claude_export_corpus(
             "gates": [],
         },
     )
-    write_json(output_root / "import-manifest.json", import_manifest)
+    write_corpus_collection(
+        output_root / "import-manifest.json",
+        import_manifest,
+        authorization=authorization,
+    )
     write_markdown(
         output_root / "README.md",
         "\n".join(
@@ -969,7 +1045,7 @@ def import_claude_export_corpus(
         "empty_conversation_count": empty_conversation_count,
         "near_duplicate_count": len(near_duplicates),
         "flagged_thread_count": sum(1 for audit in thread_audits if audit.get("quality_flags")),
-        "manifest_path": str(output_root / "import-manifest.json"),
+        "manifest_path": str(collection_storage_path(output_root / "import-manifest.json")),
         "readme_path": str(output_root / "README.md"),
         "bundle_part_count": len(bundle_roots),
         "bundle_part_names": [p.name for p in bundle_roots],

--- a/src/conversation_corpus_engine/import_claude_local_session_corpus.py
+++ b/src/conversation_corpus_engine/import_claude_local_session_corpus.py
@@ -5,7 +5,7 @@ import argparse
 import json
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .answering import load_json, write_json, write_markdown
 from .claude_local_session import (
@@ -16,7 +16,11 @@ from .claude_local_session import (
     save_acquisition_state,
 )
 from .import_claude_export_corpus import import_claude_export_corpus, now_iso
+from .sharded_collection import content_hash_key, write_collection
 from .source_lifecycle import build_source_snapshot
+
+if TYPE_CHECKING:
+    from .corpus_store import CorpusWriteAuthorization
 
 DEFAULT_OUTPUT_ROOT = Path.cwd() / "claude-local-session-memory"
 DEFAULT_CORPUS_ID = "claude-local-session-memory"
@@ -49,7 +53,15 @@ def write_local_session_bundle(bundle_root: Path, bundle: dict[str, Any]) -> Non
         bundle_root / "conversation-detail-failures.json",
         bundle.get("conversation_detail_failures") or [],
     )
-    write_json(bundle_root / "conversations.json", bundle.get("conversations") or [])
+    write_collection(
+        bundle_root / "conversations.json",
+        bundle.get("conversations") or [],
+        key=lambda record: (
+            str(record.get("uuid") or record.get("id"))
+            if isinstance(record, dict) and (record.get("uuid") or record.get("id"))
+            else content_hash_key(record)
+        ),
+    )
     details_root = bundle_root / "conversation-details"
     details_root.mkdir(parents=True, exist_ok=True)
     for conversation in bundle.get("conversations") or []:
@@ -140,6 +152,7 @@ def import_claude_local_session_corpus(
     corpus_id: str = DEFAULT_CORPUS_ID,
     name: str = DEFAULT_NAME,
     throttle: float = 0.0,
+    authorization: CorpusWriteAuthorization | None = None,
 ) -> dict[str, Any]:
     local_root = local_root.resolve()
     discovery = discover_claude_local_session(local_root)
@@ -169,7 +182,12 @@ def import_claude_local_session_corpus(
         bundle_root = Path(tmpdir) / "claude-local-bundle"
         write_local_session_bundle(bundle_root, bundle)
         result = import_claude_export_corpus(
-            bundle_root, output_root, corpus_id=corpus_id, name=name, throttle=throttle
+            bundle_root,
+            output_root,
+            corpus_id=corpus_id,
+            name=name,
+            throttle=throttle,
+            authorization=authorization,
         )
         source_root = output_root / "source"
         source_root.mkdir(parents=True, exist_ok=True)

--- a/src/conversation_corpus_engine/import_document_export_corpus.py
+++ b/src/conversation_corpus_engine/import_document_export_corpus.py
@@ -11,21 +11,25 @@ import zipfile
 from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .answering import load_json, slugify, write_json, write_markdown
 from .import_markdown_document_corpus import import_markdown_document_corpus
 from .provider_catalog import get_provider_config
 from .provider_exports import collect_supported_export_files
+from .sharded_collection import collection_storage_path, write_corpus_collection
 from .source_lifecycle import build_source_snapshot
 
 DEFAULT_OUTPUT_ROOT = Path.cwd() / "document-export-memory"
-CONTRACT_NAME = "conversation-corpus-engine-v1"
-CONTRACT_VERSION = 1
+CONTRACT_NAME = "conversation-corpus-engine.v2"
+CONTRACT_VERSION = 2
 SUPPORTED_PLAINTEXT_SUFFIXES = {".md", ".markdown", ".txt"}
 SUPPORTED_HTML_SUFFIXES = {".html", ".htm"}
 SUPPORTED_JSON_SUFFIXES = {".json"}
 SUPPORTED_CSV_SUFFIXES = {".csv"}
+
+if TYPE_CHECKING:
+    from .corpus_store import CorpusWriteAuthorization
 
 
 def now_iso() -> str:
@@ -295,6 +299,7 @@ def import_document_export_corpus(
     corpus_id: str | None = None,
     name: str | None = None,
     throttle: float = 0.0,
+    authorization: CorpusWriteAuthorization | None = None,
 ) -> dict[str, Any]:
     config = get_provider_config(provider_slug)
     provider_name = config["display_name"]
@@ -335,6 +340,7 @@ def import_document_export_corpus(
                 output_root,
                 corpus_id=corpus_id,
                 name=default_name,
+                authorization=authorization,
             )
             raw_copy_map = build_raw_source_copy_map(
                 input_path=input_path,
@@ -397,7 +403,11 @@ def import_document_export_corpus(
                 "gates": [],
             },
         )
-        write_json(output_root / "import-manifest.json", import_manifest)
+        write_corpus_collection(
+            output_root / "import-manifest.json",
+            import_manifest,
+            authorization=authorization,
+        )
         write_markdown(
             output_root / "README.md",
             "\n".join(
@@ -427,7 +437,7 @@ def import_document_export_corpus(
             "source_file_count": len(source_files),
             "format_counts": dict(format_counts),
             "archive_type": archive_type,
-            "manifest_path": str(output_root / "import-manifest.json"),
+            "manifest_path": str(collection_storage_path(output_root / "import-manifest.json")),
             "readme_path": str(output_root / "README.md"),
         }
     finally:

--- a/src/conversation_corpus_engine/import_markdown_document_corpus.py
+++ b/src/conversation_corpus_engine/import_markdown_document_corpus.py
@@ -8,14 +8,23 @@ import shutil
 from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .answering import slugify, tokenize, write_json, write_markdown
+from .sharded_collection import (
+    collection_storage_path,
+    merge_entity_records,
+    merge_ledger_records,
+    write_corpus_collection,
+)
 from .source_lifecycle import build_source_snapshot
 
+if TYPE_CHECKING:
+    from .corpus_store import CorpusWriteAuthorization
+
 DEFAULT_OUTPUT_ROOT = Path.cwd() / "markdown-document-memory"
-CONTRACT_NAME = "conversation-corpus-engine-v1"
-CONTRACT_VERSION = 1
+CONTRACT_NAME = "conversation-corpus-engine.v2"
+CONTRACT_VERSION = 2
 H1_RE = re.compile(r"^\s*#\s+(.+?)\s*$", re.MULTILINE)
 LIST_PREFIX_RE = re.compile(r"^\s*(?:[-*+]\s+|\d+[.)]\s+)")
 FOOTNOTE_RE = re.compile(r"\[\^[^\]]+\]")
@@ -352,6 +361,7 @@ def import_markdown_document_corpus(
     corpus_id: str | None = None,
     name: str | None = None,
     max_depth: int | None = None,
+    authorization: CorpusWriteAuthorization | None = None,
 ) -> dict[str, Any]:
     markdown_files = collect_markdown_files(input_path, max_depth=max_depth)
     if not markdown_files:
@@ -548,17 +558,44 @@ def import_markdown_document_corpus(
     corpus_dir = output_root / "corpus"
     collection_scope = "top-level" if max_depth == 1 and input_path.is_dir() else "recursive"
     source_snapshot = build_source_snapshot(input_path, "markdown-document", collection_scope)
-    write_json(corpus_dir / "threads-index.json", threads)
-    write_json(corpus_dir / "semantic-v3-index.json", {"threads": semantic_threads})
-    write_json(corpus_dir / "pairs-index.json", pairs)
-    write_json(corpus_dir / "doctrine-briefs.json", doctrine_briefs)
-    write_json(corpus_dir / "family-dossiers.json", family_dossiers)
-    write_json(corpus_dir / "canonical-families.json", canonical_families)
-    write_json(corpus_dir / "action-ledger.json", actions)
-    write_json(corpus_dir / "unresolved-ledger.json", unresolved)
-    write_json(corpus_dir / "canonical-entities.json", entities)
-    write_json(corpus_dir / "entity-aliases.json", entity_aliases)
-    write_json(corpus_dir / "doctrine-timeline.json", [])
+    actions = merge_ledger_records(
+        actions,
+        key_field="action_key",
+        text_field="canonical_action",
+    )
+    unresolved = merge_ledger_records(
+        unresolved,
+        key_field="question_key",
+        text_field="canonical_question",
+    )
+    entities = merge_entity_records(entities)
+    entity_aliases = [
+        {
+            "canonical_label": entity["canonical_label"],
+            "labels": entity.get("aliases") or [],
+        }
+        for entity in entities
+        if entity.get("aliases")
+    ]
+    collections = {
+        "threads-index.json": threads,
+        "semantic-v3-index.json": semantic_threads,
+        "pairs-index.json": pairs,
+        "doctrine-briefs.json": doctrine_briefs,
+        "family-dossiers.json": family_dossiers,
+        "canonical-families.json": canonical_families,
+        "action-ledger.json": actions,
+        "unresolved-ledger.json": unresolved,
+        "canonical-entities.json": entities,
+        "entity-aliases.json": entity_aliases,
+        "doctrine-timeline.json": [],
+    }
+    for filename, records in collections.items():
+        write_corpus_collection(
+            corpus_dir / filename,
+            records,
+            authorization=authorization,
+        )
     write_json(corpus_dir / "source-snapshot.json", source_snapshot)
     write_json(
         corpus_dir / "contract.json",
@@ -570,11 +607,11 @@ def import_markdown_document_corpus(
             "name": name or output_root.name,
             "generated_at": now_iso(),
             "required_files": [
-                "corpus/threads-index.json",
-                "corpus/semantic-v3-index.json",
-                "corpus/pairs-index.json",
-                "corpus/doctrine-briefs.json",
-                "corpus/family-dossiers.json",
+                "corpus/threads-index.collection",
+                "corpus/semantic-v3-index.collection",
+                "corpus/pairs-index.collection",
+                "corpus/doctrine-briefs.collection",
+                "corpus/family-dossiers.collection",
             ],
             "counts": {
                 "threads": len(threads),
@@ -612,7 +649,11 @@ def import_markdown_document_corpus(
             "gates": [],
         },
     )
-    write_json(output_root / "import-manifest.json", import_manifest)
+    write_corpus_collection(
+        output_root / "import-manifest.json",
+        import_manifest,
+        authorization=authorization,
+    )
     write_markdown(
         output_root / "README.md",
         "\n".join(
@@ -641,7 +682,7 @@ def import_markdown_document_corpus(
         "thread_count": len(threads),
         "action_count": len(actions),
         "unresolved_count": len(unresolved),
-        "manifest_path": str(output_root / "import-manifest.json"),
+        "manifest_path": str(collection_storage_path(output_root / "import-manifest.json")),
         "readme_path": str(output_root / "README.md"),
     }
 

--- a/src/conversation_corpus_engine/migration.py
+++ b/src/conversation_corpus_engine/migration.py
@@ -1,8 +1,42 @@
 from __future__ import annotations
 
+import json
+import shutil
 from pathlib import Path
+from typing import Any
 
+from .corpus_store import authorize_corpus_write
 from .federation import upsert_corpus, validate_corpus_root
+from .schema_validation import validate_payload
+from .sharded_collection import (
+    collection_current_path,
+    collection_storage_path,
+    content_hash_key,
+    load_collection,
+    load_corpus_collection,
+    merge_entity_records,
+    merge_ledger_records,
+    write_collection,
+    write_corpus_collection,
+)
+
+MIGRATABLE_CORPUS_COLLECTIONS = (
+    "threads-index.json",
+    "semantic-v3-index.json",
+    "pairs-index.json",
+    "doctrine-briefs.json",
+    "family-dossiers.json",
+    "canonical-families.json",
+    "action-ledger.json",
+    "unresolved-ledger.json",
+    "canonical-entities.json",
+    "entity-aliases.json",
+    "doctrine-timeline.json",
+    "import-audit.json",
+    "near-duplicates.json",
+)
+V2_CONTRACT_NAME = "conversation-corpus-engine.v2"
+V2_CONTRACT_VERSION = 2
 
 
 def discover_staging_corpora(staging_root: Path) -> list[Path]:
@@ -51,3 +85,218 @@ def seed_registry_from_staging(
         "registered_count": len(registered),
         "registered": registered,
     }
+
+
+def _copy_non_collection_files(source_root: Path, destination_root: Path) -> list[str]:
+    copied: list[str] = []
+    excluded_corpus_files = {*MIGRATABLE_CORPUS_COLLECTIONS, "contract.json"}
+    for path in sorted(source_root.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(source_root)
+        if any(parent.name.endswith(".collection") for parent in path.parents):
+            continue
+        if relative.parts[:1] == ("corpus",) and path.name in excluded_corpus_files:
+            continue
+        if relative.parts[:1] == ("source",) and path.name == "conversations.json":
+            continue
+        if relative.as_posix() == "import-manifest.json":
+            continue
+        destination = destination_root / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, destination)
+        copied.append(relative.as_posix())
+    return copied
+
+
+def _source_conversation_key(record: Any) -> str:
+    if isinstance(record, dict):
+        for field in ("conversation_id", "uuid", "id"):
+            value = record.get(field)
+            if value:
+                return str(value)
+    return content_hash_key(record)
+
+
+def _merge_alias_records(records: list[Any]) -> list[dict[str, Any]]:
+    merged: dict[str, dict[str, Any]] = {}
+    for record in records:
+        if not isinstance(record, dict):
+            raise ValueError("Legacy entity alias records must be JSON objects.")
+        key = str(record.get("canonical_entity_id") or record.get("canonical_label") or "")
+        if not key:
+            raise ValueError("Legacy entity alias record is missing a stable identity.")
+        existing = merged.get(key)
+        if existing is None:
+            merged[key] = {
+                **record,
+                "labels": list(record.get("labels") or []),
+            }
+            continue
+        existing["labels"] = list(
+            dict.fromkeys([*existing["labels"], *(record.get("labels") or [])])
+        )
+    return list(merged.values())
+
+
+def _normalize_legacy_collection(filename: str, records: list[Any]) -> list[Any]:
+    if filename == "action-ledger.json":
+        return merge_ledger_records(
+            records,
+            key_field="action_key",
+            text_field="canonical_action",
+        )
+    if filename == "unresolved-ledger.json":
+        return merge_ledger_records(
+            records,
+            key_field="question_key",
+            text_field="canonical_question",
+        )
+    if filename == "canonical-entities.json":
+        return merge_entity_records(records)
+    if filename == "entity-aliases.json":
+        return _merge_alias_records(records)
+    return records
+
+
+def migrate_corpus_v2(
+    *,
+    project_root: Path,
+    source_root: Path,
+    destination_root: Path,
+    corpus_store_root: Path | None = None,
+    write: bool = False,
+) -> dict[str, Any]:
+    source_root = source_root.resolve(strict=True)
+    destination_root = destination_root.resolve(strict=False)
+    validation = validate_corpus_root(source_root)
+    if not validation["valid"]:
+        missing = ", ".join(validation["missing_files"])
+        raise ValueError(f"Source corpus is missing required collections: {missing}")
+    if validation.get("contract_name") != "conversation-corpus-engine-v1":
+        raise ValueError("corpus-v2 migration requires a conversation-corpus-engine-v1 source.")
+
+    source_corpus = source_root / "corpus"
+    available: dict[str, list[Any]] = {}
+    for filename in MIGRATABLE_CORPUS_COLLECTIONS:
+        logical_path = source_corpus / filename
+        if collection_storage_path(logical_path).exists():
+            raise ValueError(
+                "corpus-v2 migration requires a v1 source without an existing v2 generation: "
+                f"{logical_path}"
+            )
+        if logical_path.is_file():
+            records = load_corpus_collection(logical_path, default=[]) or []
+            available[filename] = _normalize_legacy_collection(filename, records)
+
+    plan: dict[str, Any] = {
+        "migration": "conversation-corpus-engine.v1-to-v2",
+        "mode": "write" if write else "read-only",
+        "source_root": str(source_root),
+        "destination_root": str(destination_root),
+        "collection_counts": {filename: len(records) for filename, records in available.items()},
+        "collection_count": len(available),
+        "source_unchanged": True,
+    }
+    if not write:
+        return plan
+
+    authorization = authorize_corpus_write(
+        project_root=project_root,
+        corpus_store_root=corpus_store_root,
+        destination=destination_root,
+        source_roots=(source_root,),
+    )
+    destination_root = authorization.destination
+    destination_corpus = destination_root / "corpus"
+    destination_corpus.mkdir(parents=True, exist_ok=True)
+    copied_files = _copy_non_collection_files(source_root, destination_root)
+
+    generations: dict[str, str] = {}
+    for filename, records in available.items():
+        logical_path = destination_corpus / filename
+        if logical_path.exists():
+            raise ValueError(f"Destination contains a legacy collection file: {logical_path}")
+        manifest = write_corpus_collection(
+            logical_path,
+            records,
+            authorization=authorization,
+        )
+        generations[filename] = manifest["generation_id"]
+
+    source_directory = source_root / "source"
+    source_conversation_files = (
+        sorted(source_directory.rglob("conversations.json")) if source_directory.is_dir() else []
+    )
+    for source_conversations in source_conversation_files:
+        relative = source_conversations.relative_to(source_root)
+        destination_conversations = destination_root / relative
+        manifest = write_collection(
+            destination_conversations,
+            load_collection(source_conversations, default=[]),
+            key=_source_conversation_key,
+            authorization=authorization,
+        )
+        generations[relative.as_posix()] = manifest["generation_id"]
+
+    source_import_manifest = source_root / "import-manifest.json"
+    if source_import_manifest.is_file():
+        manifest = write_corpus_collection(
+            destination_root / "import-manifest.json",
+            load_corpus_collection(source_import_manifest, default=[]),
+            authorization=authorization,
+        )
+        generations["import-manifest.json"] = manifest["generation_id"]
+
+    source_contract_path = source_corpus / "contract.json"
+    source_contract = (
+        json.loads(source_contract_path.read_text(encoding="utf-8"))
+        if source_contract_path.is_file()
+        else {}
+    )
+    counts = dict(source_contract.get("counts") or {})
+    for count_name, filename in {
+        "threads": "threads-index.json",
+        "families": "canonical-families.json",
+        "pairs": "pairs-index.json",
+        "actions": "action-ledger.json",
+        "unresolved": "unresolved-ledger.json",
+        "entities": "canonical-entities.json",
+        "near_duplicates": "near-duplicates.json",
+    }.items():
+        if filename in available:
+            counts[count_name] = len(available[filename])
+    contract = {
+        **source_contract,
+        "contract_name": V2_CONTRACT_NAME,
+        "contract_version": V2_CONTRACT_VERSION,
+        "required_files": [
+            f"corpus/{Path(filename).with_suffix('.collection').name}"
+            for filename in MIGRATABLE_CORPUS_COLLECTIONS[:5]
+        ],
+        "counts": counts,
+    }
+    contract_validation = validate_payload("corpus-contract", contract)
+    if not contract_validation["valid"]:
+        raise ValueError(
+            "Migrated corpus contract is invalid: "
+            + "; ".join(item["message"] for item in contract_validation["errors"])
+        )
+    contract_path = destination_corpus / "contract.json"
+    contract_path.write_text(json.dumps(contract, indent=2) + "\n", encoding="utf-8")
+
+    plan.update(
+        {
+            "destination_root": str(destination_root),
+            "copied_file_count": len(copied_files),
+            "generation_ids": generations,
+            "contract_validation": contract_validation,
+            "current_pointers": {
+                filename: collection_current_path(destination_corpus / filename)
+                .read_text(encoding="utf-8")
+                .strip()
+                for filename in available
+            },
+        }
+    )
+    return plan

--- a/src/conversation_corpus_engine/persona_extract.py
+++ b/src/conversation_corpus_engine/persona_extract.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from .answering import STOP_WORDS, load_json, shorten, tokenize
+from .sharded_collection import collection_exists, iter_corpus_collection
 
 # Persona identifiers that denote the assistant/model side of a transcript.
 # Everything else (rob, user, human, operator, ...) is treated as a human persona.
@@ -259,8 +260,8 @@ def _collect_segments(source: Path, persona_id: str) -> tuple[list[str], list[st
     turns: list[tuple[str, str]] = []
 
     pairs_index = source / "corpus" / "pairs-index.json"
-    if pairs_index.exists():
-        for pair in load_json(pairs_index, default=[]) or []:
+    if collection_exists(pairs_index):
+        for pair in iter_corpus_collection(pairs_index):
             summary = pair.get("summary") or pair.get("search_text") or ""
             user_segment, assistant_segment = _split_pair_summary(summary)
             turns.append(("user", user_segment))

--- a/src/conversation_corpus_engine/provider_import.py
+++ b/src/conversation_corpus_engine/provider_import.py
@@ -146,6 +146,7 @@ def import_provider_corpus(
             corpus_id=resolved_corpus_id,
             name=resolved_name,
             throttle=throttle,
+            authorization=authorization,
         )
     elif provider == "chatgpt" and mode == "local-session":
         import_result = import_chatgpt_local_session_corpus(
@@ -154,6 +155,7 @@ def import_provider_corpus(
             corpus_id=resolved_corpus_id,
             name=resolved_name,
             throttle=throttle,
+            authorization=authorization,
         )
     elif provider == "chatgpt":
         import_result = import_chatgpt_export_corpus(
@@ -162,6 +164,7 @@ def import_provider_corpus(
             corpus_id=resolved_corpus_id,
             name=resolved_name,
             throttle=throttle,
+            authorization=authorization,
         )
     elif provider == "claude":
         import_result = import_claude_export_corpus(
@@ -170,6 +173,7 @@ def import_provider_corpus(
             corpus_id=resolved_corpus_id,
             name=resolved_name,
             throttle=throttle,
+            authorization=authorization,
         )
     else:
         import_result = import_document_export_corpus(
@@ -179,6 +183,7 @@ def import_provider_corpus(
             corpus_id=resolved_corpus_id,
             name=resolved_name,
             throttle=throttle,
+            authorization=authorization,
         )
 
     bootstrap_result = (

--- a/src/conversation_corpus_engine/schema_validation.py
+++ b/src/conversation_corpus_engine/schema_validation.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from .sharded_collection import collection_storage_path, load_corpus_collection
+
 SCHEMA_CATALOG = {
     "commercial-awareness": {
         "filename": "commercial-awareness.schema.json",
@@ -24,6 +26,10 @@ SCHEMA_CATALOG = {
     "source-policy": {
         "filename": "source-policy.schema.json",
         "description": "Per-provider source authority policy under state/source-policies/<provider>.json.",
+    },
+    "sharded-collection": {
+        "filename": "sharded-collection.schema.json",
+        "description": "Immutable generation manifest for a cce.sharded_collection.v1 collection.",
     },
     "promotion-policy": {
         "filename": "promotion-policy.schema.json",
@@ -188,8 +194,11 @@ def validate_payload(schema_name: str, payload: Any) -> dict[str, Any]:
 
 
 def validate_json_file(schema_name: str, path: Path) -> dict[str, Any]:
-    resolved_path = path.resolve()
-    payload = json.loads(resolved_path.read_text(encoding="utf-8"))
+    resolved_path = path.resolve(strict=False)
+    if collection_storage_path(resolved_path).exists():
+        payload = load_corpus_collection(resolved_path, default=[])
+    else:
+        payload = json.loads(resolved_path.read_text(encoding="utf-8"))
     result = validate_payload(schema_name, payload)
     result["path"] = str(resolved_path)
     return result

--- a/src/conversation_corpus_engine/schemas/corpus-contract.schema.json
+++ b/src/conversation_corpus_engine/schemas/corpus-contract.schema.json
@@ -12,7 +12,10 @@
   ],
   "properties": {
     "contract_name": {
-      "const": "conversation-corpus-engine-v1"
+      "enum": [
+        "conversation-corpus-engine-v1",
+        "conversation-corpus-engine.v2"
+      ]
     },
     "contract_version": {
       "type": "integer"

--- a/src/conversation_corpus_engine/schemas/sharded-collection.schema.json
+++ b/src/conversation_corpus_engine/schemas/sharded-collection.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CCE Sharded Collection Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_name",
+    "contract_version",
+    "logical_name",
+    "record_count",
+    "limits",
+    "shards",
+    "generation_id"
+  ],
+  "properties": {
+    "contract_name": {
+      "const": "cce.sharded_collection.v1"
+    },
+    "contract_version": {
+      "const": 1
+    },
+    "logical_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "record_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "max_shard_bytes",
+        "max_shard_records"
+      ],
+      "properties": {
+        "max_shard_bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 8388608
+        },
+        "max_shard_records": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000
+        }
+      }
+    },
+    "shards": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "prefix",
+          "path",
+          "record_count",
+          "byte_count",
+          "sha256",
+          "min_ordinal",
+          "max_ordinal"
+        ],
+        "properties": {
+          "prefix": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{2,64}$"
+          },
+          "path": {
+            "type": "string",
+            "pattern": "^shards/[a-f0-9]{2,64}\\.jsonl$"
+          },
+          "record_count": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000
+          },
+          "byte_count": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 8388608
+          },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$"
+          },
+          "min_ordinal": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "max_ordinal": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      }
+    },
+    "generation_id": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{32}$"
+    }
+  }
+}

--- a/src/conversation_corpus_engine/sharded_collection.py
+++ b/src/conversation_corpus_engine/sharded_collection.py
@@ -1,0 +1,820 @@
+from __future__ import annotations
+
+import hashlib
+import heapq
+import json
+import re
+import shutil
+import uuid
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .corpus_store import CorpusWriteAuthorization
+
+SHARDED_COLLECTION_CONTRACT = "cce.sharded_collection.v1"
+SHARDED_COLLECTION_VERSION = 1
+MAX_SHARD_BYTES = 8 * 1024 * 1024
+MAX_SHARD_RECORDS = 1_000
+INITIAL_PREFIX_LENGTH = 2
+CURRENT_GENERATION_PATTERN = re.compile(r"^[a-f0-9]{32}$")
+
+CORPUS_COLLECTION_KEY_FIELDS: dict[str, tuple[str, ...]] = {
+    "action-ledger.json": ("action_key",),
+    "actions-index.json": ("federated_action_id",),
+    "canonical-actions.json": ("federated_action_id",),
+    "canonical-entities.json": (
+        "canonical_entity_id",
+        "federated_entity_id",
+        "entity_id",
+        "canonical_label",
+    ),
+    "canonical-families.json": (
+        "canonical_family_id",
+        "federated_family_id",
+        "family_id",
+    ),
+    "canonical-unresolved.json": ("federated_question_id",),
+    "corpora-summary.json": ("corpus_id",),
+    "doctrine-briefs.json": ("family_id", "canonical_family_id", "federated_family_id"),
+    "doctrine-timeline.json": ("canonical_family_id", "family_id"),
+    "entity-aliases.json": ("canonical_entity_id", "canonical_label"),
+    "entity-dossiers.json": ("federated_entity_id",),
+    "entities-index.json": ("federated_entity_id",),
+    "family-dossiers.json": ("family_id", "canonical_family_id"),
+    "families-index.json": ("federated_family_id",),
+    "import-audit.json": ("thread_uid", "conversation_id", "id"),
+    "import-manifest.json": (
+        "conversation_uuid",
+        "thread_uid",
+        "source_export",
+        "source_markdown",
+        "relative_path",
+    ),
+    "near-duplicates.json": ("duplicate_id", "pair_id", "thread_uid", "id"),
+    "pairs-index.json": ("pair_id",),
+    "project-dossiers.json": ("federated_family_id", "project_id"),
+    "lineage-map.json": ("federated_family_id",),
+    "semantic-v3-index.json": ("thread_uid",),
+    "threads-index.json": ("thread_uid",),
+    "unresolved-index.json": ("federated_question_id",),
+    "unresolved-ledger.json": ("question_key",),
+}
+
+
+class ShardedCollectionError(ValueError):
+    """Raised when sharded collection state is invalid or cannot be published safely."""
+
+
+def canonical_json_bytes(payload: Any) -> bytes:
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def content_hash_key(payload: Any) -> str:
+    return hashlib.sha256(canonical_json_bytes(payload)).hexdigest()
+
+
+def collection_storage_path(logical_path: Path) -> Path:
+    if logical_path.suffix:
+        return logical_path.with_suffix(".collection")
+    return logical_path.with_name(f"{logical_path.name}.collection")
+
+
+def collection_current_path(logical_path: Path) -> Path:
+    return collection_storage_path(logical_path) / "CURRENT"
+
+
+def collection_generations_path(logical_path: Path) -> Path:
+    return collection_storage_path(logical_path) / "generations"
+
+
+def collection_exists(logical_path: Path) -> bool:
+    logical_path = logical_path.resolve(strict=False)
+    if collection_storage_path(logical_path).exists():
+        validate_collection(logical_path)
+        return True
+    return logical_path.is_file()
+
+
+def _record_key_from_fields(record: Any, fields: Sequence[str]) -> str:
+    if not isinstance(record, dict):
+        raise ShardedCollectionError("Collection records must be JSON objects.")
+    for field in fields:
+        value = record.get(field)
+        if isinstance(value, (str, int)) and str(value):
+            return str(value)
+    raise ShardedCollectionError(
+        f"Collection record is missing a stable key field from: {', '.join(fields)}"
+    )
+
+
+def corpus_collection_key(logical_path: Path, record: Any) -> str:
+    if logical_path.name == "near-duplicates.json":
+        if not isinstance(record, dict):
+            raise ShardedCollectionError("Collection records must be JSON objects.")
+        thread_uids = record.get("thread_uids")
+        if isinstance(thread_uids, list) and len(thread_uids) >= 2:
+            values = [str(value) for value in thread_uids if value]
+            if len(values) == len(thread_uids):
+                return "\0".join(sorted(values))
+    fields = CORPUS_COLLECTION_KEY_FIELDS.get(logical_path.name)
+    if fields is None:
+        raise ShardedCollectionError(
+            f"No stable-key contract is registered for collection: {logical_path.name}"
+        )
+    return _record_key_from_fields(record, fields)
+
+
+def merge_ledger_records(
+    records: Iterable[dict[str, Any]],
+    *,
+    key_field: str,
+    text_field: str,
+) -> list[dict[str, Any]]:
+    merged: dict[str, dict[str, Any]] = {}
+    for record in records:
+        key = str(record.get(key_field) or "")
+        if not key:
+            raise ShardedCollectionError(f"Ledger record is missing {key_field}.")
+        existing = merged.get(key)
+        if existing is None:
+            merged[key] = {
+                **record,
+                "family_ids": list(record.get("family_ids") or []),
+                "thread_uids": list(record.get("thread_uids") or []),
+            }
+            continue
+        if existing.get(text_field) != record.get(text_field):
+            raise ShardedCollectionError(
+                f"Ledger key collision has conflicting {text_field}: {key}"
+            )
+        existing["family_ids"] = list(
+            dict.fromkeys([*existing["family_ids"], *(record.get("family_ids") or [])])
+        )
+        existing["thread_uids"] = list(
+            dict.fromkeys([*existing["thread_uids"], *(record.get("thread_uids") or [])])
+        )
+        existing["occurrence_count"] = int(existing.get("occurrence_count") or 0) + int(
+            record.get("occurrence_count") or 0
+        )
+    return list(merged.values())
+
+
+def merge_entity_records(records: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    merged: dict[str, dict[str, Any]] = {}
+    for record in records:
+        key = str(record.get("canonical_entity_id") or "")
+        if not key:
+            raise ShardedCollectionError("Entity record is missing canonical_entity_id.")
+        existing = merged.get(key)
+        if existing is None:
+            merged[key] = {
+                **record,
+                "aliases": list(record.get("aliases") or []),
+            }
+            continue
+        if existing.get("canonical_label") != record.get("canonical_label") or existing.get(
+            "entity_type"
+        ) != record.get("entity_type"):
+            raise ShardedCollectionError(f"Entity key collision has conflicting identity: {key}")
+        existing["aliases"] = list(
+            dict.fromkeys([*existing["aliases"], *(record.get("aliases") or [])])
+        )
+    return list(merged.values())
+
+
+def _encode_envelope(key: str, ordinal: int, record: Any) -> bytes:
+    return (
+        canonical_json_bytes(
+            {
+                "key": key,
+                "ordinal": ordinal,
+                "record": record,
+            }
+        )
+        + b"\n"
+    )
+
+
+def _prepare_records(
+    records: Iterable[Any],
+    key: Callable[[Any], str],
+    *,
+    max_shard_bytes: int,
+) -> list[dict[str, Any]]:
+    prepared: list[dict[str, Any]] = []
+    seen_keys: set[str] = set()
+    for ordinal, record in enumerate(records):
+        stable_key = key(record)
+        if not isinstance(stable_key, str) or not stable_key:
+            raise ShardedCollectionError("Collection stable keys must be non-empty strings.")
+        if stable_key in seen_keys:
+            raise ShardedCollectionError(f"Duplicate collection key: {stable_key}")
+        seen_keys.add(stable_key)
+        encoded = _encode_envelope(stable_key, ordinal, record)
+        if len(encoded) > max_shard_bytes:
+            raise ShardedCollectionError(
+                f"Collection record {stable_key!r} exceeds the shard byte limit."
+            )
+        prepared.append(
+            {
+                "key": stable_key,
+                "key_hash": hashlib.sha256(stable_key.encode("utf-8")).hexdigest(),
+                "ordinal": ordinal,
+                "record": record,
+                "encoded": encoded,
+            }
+        )
+    return prepared
+
+
+def _bucket_within_limits(
+    items: Sequence[dict[str, Any]],
+    *,
+    max_shard_bytes: int,
+    max_shard_records: int,
+) -> bool:
+    return len(items) <= max_shard_records and sum(len(item["encoded"]) for item in items) <= (
+        max_shard_bytes
+    )
+
+
+def _split_bucket(
+    prefix: str,
+    items: Sequence[dict[str, Any]],
+    *,
+    max_shard_bytes: int,
+    max_shard_records: int,
+) -> dict[str, list[dict[str, Any]]]:
+    if _bucket_within_limits(
+        items,
+        max_shard_bytes=max_shard_bytes,
+        max_shard_records=max_shard_records,
+    ):
+        return {prefix: list(items)}
+    if len(prefix) >= 64:
+        raise ShardedCollectionError(
+            f"Hash-prefix bucket {prefix!r} cannot be split within shard limits."
+        )
+    children: dict[str, list[dict[str, Any]]] = {}
+    for item in items:
+        child_prefix = item["key_hash"][: len(prefix) + 1]
+        children.setdefault(child_prefix, []).append(item)
+    if len(children) == 1:
+        child_prefix, child_items = next(iter(children.items()))
+        return _split_bucket(
+            child_prefix,
+            child_items,
+            max_shard_bytes=max_shard_bytes,
+            max_shard_records=max_shard_records,
+        )
+    result: dict[str, list[dict[str, Any]]] = {}
+    for child_prefix in sorted(children):
+        result.update(
+            _split_bucket(
+                child_prefix,
+                children[child_prefix],
+                max_shard_bytes=max_shard_bytes,
+                max_shard_records=max_shard_records,
+            )
+        )
+    return result
+
+
+def _partition_records(
+    records: Sequence[dict[str, Any]],
+    *,
+    max_shard_bytes: int,
+    max_shard_records: int,
+) -> dict[str, list[dict[str, Any]]]:
+    initial: dict[str, list[dict[str, Any]]] = {}
+    for item in records:
+        prefix = item["key_hash"][:INITIAL_PREFIX_LENGTH]
+        initial.setdefault(prefix, []).append(item)
+    shards: dict[str, list[dict[str, Any]]] = {}
+    for prefix in sorted(initial):
+        shards.update(
+            _split_bucket(
+                prefix,
+                initial[prefix],
+                max_shard_bytes=max_shard_bytes,
+                max_shard_records=max_shard_records,
+            )
+        )
+    return shards
+
+
+def _manifest_core(
+    logical_path: Path,
+    *,
+    record_count: int,
+    shards: list[dict[str, Any]],
+    max_shard_bytes: int,
+    max_shard_records: int,
+) -> dict[str, Any]:
+    return {
+        "contract_name": SHARDED_COLLECTION_CONTRACT,
+        "contract_version": SHARDED_COLLECTION_VERSION,
+        "logical_name": logical_path.name,
+        "record_count": record_count,
+        "limits": {
+            "max_shard_bytes": max_shard_bytes,
+            "max_shard_records": max_shard_records,
+        },
+        "shards": shards,
+    }
+
+
+def _generation_id(manifest_core: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_json_bytes(manifest_core)).hexdigest()[:32]
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ShardedCollectionError(
+            f"Collection manifest is missing or malformed: {path}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ShardedCollectionError(f"Collection manifest must be a JSON object: {path}")
+    return payload
+
+
+def _resolve_current_generation(logical_path: Path) -> tuple[Path, dict[str, Any]]:
+    storage_root = collection_storage_path(logical_path)
+    if storage_root.is_symlink() or not storage_root.is_dir():
+        raise ShardedCollectionError(f"Collection storage root is invalid: {storage_root}")
+    current_path = collection_current_path(logical_path)
+    if current_path.is_symlink():
+        raise ShardedCollectionError(
+            f"Collection CURRENT pointer may not be a symlink: {current_path}"
+        )
+    try:
+        generation_id = current_path.read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ShardedCollectionError(
+            f"Collection v2 state exists without a readable CURRENT pointer: {storage_root}"
+        ) from exc
+    if not CURRENT_GENERATION_PATTERN.fullmatch(generation_id):
+        raise ShardedCollectionError(f"Collection CURRENT pointer is malformed: {current_path}")
+    generation_root = collection_generations_path(logical_path) / generation_id
+    if generation_root.is_symlink() or not generation_root.is_dir():
+        raise ShardedCollectionError(f"Collection generation is missing: {generation_root}")
+    manifest = _load_manifest(generation_root / "manifest.json")
+    if manifest.get("generation_id") != generation_id:
+        raise ShardedCollectionError(
+            f"Collection manifest generation does not match CURRENT: {generation_root}"
+        )
+    return generation_root, manifest
+
+
+def _validate_manifest_shape(
+    logical_path: Path,
+    generation_root: Path,
+    manifest: dict[str, Any],
+) -> list[dict[str, Any]]:
+    if set(manifest) != {
+        "contract_name",
+        "contract_version",
+        "logical_name",
+        "record_count",
+        "limits",
+        "shards",
+        "generation_id",
+    }:
+        raise ShardedCollectionError(f"Collection manifest fields are invalid: {generation_root}")
+    if manifest.get("contract_name") != SHARDED_COLLECTION_CONTRACT:
+        raise ShardedCollectionError(f"Unsupported collection contract: {generation_root}")
+    if manifest.get("contract_version") != SHARDED_COLLECTION_VERSION:
+        raise ShardedCollectionError(f"Unsupported collection contract version: {generation_root}")
+    if manifest.get("logical_name") != logical_path.name:
+        raise ShardedCollectionError(f"Collection logical name mismatch: {generation_root}")
+    record_count = manifest.get("record_count")
+    if not isinstance(record_count, int) or record_count < 0:
+        raise ShardedCollectionError(f"Collection record count is invalid: {generation_root}")
+    limits = manifest.get("limits")
+    if not isinstance(limits, dict) or set(limits) != {
+        "max_shard_bytes",
+        "max_shard_records",
+    }:
+        raise ShardedCollectionError(f"Collection limits are missing: {generation_root}")
+    for field in ("max_shard_bytes", "max_shard_records"):
+        if not isinstance(limits.get(field), int) or limits[field] <= 0:
+            raise ShardedCollectionError(f"Collection limit {field} is invalid: {generation_root}")
+    if (
+        limits["max_shard_bytes"] > MAX_SHARD_BYTES
+        or limits["max_shard_records"] > MAX_SHARD_RECORDS
+    ):
+        raise ShardedCollectionError(f"Collection limits exceed the contract: {generation_root}")
+    shards = manifest.get("shards")
+    if not isinstance(shards, list):
+        raise ShardedCollectionError(f"Collection shard catalog is invalid: {generation_root}")
+    return shards
+
+
+def _validate_generation(
+    logical_path: Path,
+    generation_root: Path,
+    manifest: dict[str, Any],
+) -> dict[str, Any]:
+    shards = _validate_manifest_shape(logical_path, generation_root, manifest)
+    limits = manifest["limits"]
+    seen_paths: set[str] = set()
+    seen_prefixes: set[str] = set()
+    seen_keys: set[str] = set()
+    seen_ordinals: set[int] = set()
+    total_records = 0
+
+    for shard in shards:
+        if not isinstance(shard, dict) or set(shard) != {
+            "prefix",
+            "path",
+            "record_count",
+            "byte_count",
+            "sha256",
+            "min_ordinal",
+            "max_ordinal",
+        }:
+            raise ShardedCollectionError(f"Collection shard entry is invalid: {generation_root}")
+        relative_path = shard.get("path")
+        prefix = shard.get("prefix")
+        if (
+            not isinstance(relative_path, str)
+            or not relative_path.startswith("shards/")
+            or Path(relative_path).is_absolute()
+            or ".." in Path(relative_path).parts
+        ):
+            raise ShardedCollectionError(f"Collection shard path is invalid: {generation_root}")
+        if relative_path in seen_paths:
+            raise ShardedCollectionError(f"Duplicate collection shard path: {relative_path}")
+        seen_paths.add(relative_path)
+        if not isinstance(prefix, str) or not re.fullmatch(r"[a-f0-9]{2,64}", prefix):
+            raise ShardedCollectionError(f"Collection shard prefix is invalid: {relative_path}")
+        if relative_path != f"shards/{prefix}.jsonl":
+            raise ShardedCollectionError(f"Collection shard path is invalid: {relative_path}")
+        if prefix in seen_prefixes:
+            raise ShardedCollectionError(f"Duplicate collection shard prefix: {prefix}")
+        if any(
+            prefix.startswith(existing_prefix) or existing_prefix.startswith(prefix)
+            for existing_prefix in seen_prefixes
+        ):
+            raise ShardedCollectionError(f"Overlapping collection shard prefix: {prefix}")
+        seen_prefixes.add(prefix)
+
+        shard_path = generation_root / relative_path
+        if shard_path.is_symlink() or not shard_path.is_file():
+            raise ShardedCollectionError(f"Collection shard is missing: {shard_path}")
+        raw = shard_path.read_bytes()
+        if len(raw) != shard.get("byte_count") or len(raw) > limits["max_shard_bytes"]:
+            raise ShardedCollectionError(f"Collection shard byte count is invalid: {shard_path}")
+        if hashlib.sha256(raw).hexdigest() != shard.get("sha256"):
+            raise ShardedCollectionError(f"Collection shard digest mismatch: {shard_path}")
+        lines = raw.splitlines(keepends=True)
+        if len(lines) != shard.get("record_count") or len(lines) > limits["max_shard_records"]:
+            raise ShardedCollectionError(f"Collection shard record count is invalid: {shard_path}")
+        previous_ordinal = -1
+        for line in lines:
+            if not line.endswith(b"\n"):
+                raise ShardedCollectionError(f"Collection shard line lacks newline: {shard_path}")
+            try:
+                envelope = json.loads(line)
+            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                raise ShardedCollectionError(
+                    f"Collection shard contains malformed JSON: {shard_path}"
+                ) from exc
+            if not isinstance(envelope, dict) or set(envelope) != {"key", "ordinal", "record"}:
+                raise ShardedCollectionError(
+                    f"Collection shard envelope is malformed: {shard_path}"
+                )
+            key = envelope["key"]
+            ordinal = envelope["ordinal"]
+            record = envelope["record"]
+            if not isinstance(key, str) or not key:
+                raise ShardedCollectionError(f"Collection shard key is invalid: {shard_path}")
+            if hashlib.sha256(key.encode("utf-8")).hexdigest()[: len(prefix)] != prefix:
+                raise ShardedCollectionError(
+                    f"Collection shard key is mispartitioned: {shard_path}"
+                )
+            if not isinstance(ordinal, int) or ordinal < 0 or ordinal <= previous_ordinal:
+                raise ShardedCollectionError(f"Collection shard ordinals are invalid: {shard_path}")
+            if not isinstance(record, dict):
+                raise ShardedCollectionError(f"Collection record is not an object: {shard_path}")
+            if key in seen_keys:
+                raise ShardedCollectionError(f"Duplicate collection key: {key}")
+            if ordinal in seen_ordinals:
+                raise ShardedCollectionError(f"Duplicate collection ordinal: {ordinal}")
+            if line != _encode_envelope(key, ordinal, record):
+                raise ShardedCollectionError(
+                    f"Collection shard envelope is not canonical: {shard_path}"
+                )
+            seen_keys.add(key)
+            seen_ordinals.add(ordinal)
+            previous_ordinal = ordinal
+        if lines:
+            if shard.get("min_ordinal") != json.loads(lines[0])["ordinal"]:
+                raise ShardedCollectionError(
+                    f"Collection shard minimum ordinal mismatch: {shard_path}"
+                )
+            if shard.get("max_ordinal") != json.loads(lines[-1])["ordinal"]:
+                raise ShardedCollectionError(
+                    f"Collection shard maximum ordinal mismatch: {shard_path}"
+                )
+        total_records += len(lines)
+
+    shards_root = generation_root / "shards"
+    if shards_root.is_symlink():
+        raise ShardedCollectionError(f"Collection shards root may not be a symlink: {shards_root}")
+    actual_shards = (
+        {
+            path.relative_to(generation_root).as_posix()
+            for path in shards_root.rglob("*")
+            if path.is_file()
+        }
+        if shards_root.exists()
+        else set()
+    )
+    if actual_shards != seen_paths:
+        raise ShardedCollectionError(
+            f"Collection shard files do not match the manifest: {generation_root}"
+        )
+
+    if total_records != manifest["record_count"]:
+        raise ShardedCollectionError(
+            f"Collection manifest record total mismatch: {generation_root}"
+        )
+    if seen_ordinals != set(range(total_records)):
+        raise ShardedCollectionError(
+            f"Collection logical ordinals are incomplete: {generation_root}"
+        )
+    manifest_core = _manifest_core(
+        logical_path,
+        record_count=manifest["record_count"],
+        shards=shards,
+        max_shard_bytes=limits["max_shard_bytes"],
+        max_shard_records=limits["max_shard_records"],
+    )
+    if _generation_id(manifest_core) != manifest.get("generation_id"):
+        raise ShardedCollectionError(f"Collection generation digest mismatch: {generation_root}")
+    return manifest
+
+
+def validate_collection(logical_path: Path) -> dict[str, Any]:
+    logical_path = logical_path.resolve(strict=False)
+    generation_root, manifest = _resolve_current_generation(logical_path)
+    return _validate_generation(logical_path, generation_root, manifest)
+
+
+def _iter_generation_envelopes(
+    generation_root: Path,
+    manifest: dict[str, Any],
+) -> Iterator[dict[str, Any]]:
+    iterators: list[Iterator[dict[str, Any]]] = []
+    heap: list[tuple[int, int, dict[str, Any]]] = []
+    for shard in manifest["shards"]:
+        path = generation_root / shard["path"]
+
+        def iter_shard(shard_path: Path = path) -> Iterator[dict[str, Any]]:
+            with shard_path.open("r", encoding="utf-8") as handle:
+                for line in handle:
+                    yield json.loads(line)
+
+        iterator = iter_shard()
+        iterator_index = len(iterators)
+        iterators.append(iterator)
+        first = next(iterator, None)
+        if first is not None:
+            heapq.heappush(heap, (first["ordinal"], iterator_index, first))
+
+    while heap:
+        _ordinal, iterator_index, envelope = heapq.heappop(heap)
+        yield envelope
+        following = next(iterators[iterator_index], None)
+        if following is not None:
+            heapq.heappush(
+                heap,
+                (following["ordinal"], iterator_index, following),
+            )
+
+
+def iter_collection(
+    logical_path: Path,
+    *,
+    legacy_wrapper: str | None = None,
+) -> Iterator[Any]:
+    logical_path = logical_path.resolve(strict=False)
+    storage_root = collection_storage_path(logical_path)
+    if storage_root.exists():
+        manifest = validate_collection(logical_path)
+        generation_root, _loaded_manifest = _resolve_current_generation(logical_path)
+        for envelope in _iter_generation_envelopes(generation_root, manifest):
+            yield envelope["record"]
+        return
+    if not logical_path.exists():
+        return
+    try:
+        payload = json.loads(logical_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ShardedCollectionError(f"Legacy collection is malformed: {logical_path}") from exc
+    if legacy_wrapper is not None:
+        if not isinstance(payload, dict) or not isinstance(payload.get(legacy_wrapper), list):
+            raise ShardedCollectionError(
+                f"Legacy collection wrapper {legacy_wrapper!r} is malformed: {logical_path}"
+            )
+        payload = payload[legacy_wrapper]
+    if not isinstance(payload, list):
+        raise ShardedCollectionError(f"Legacy collection must be a JSON array: {logical_path}")
+    yield from payload
+
+
+def load_collection(
+    logical_path: Path,
+    *,
+    legacy_wrapper: str | None = None,
+    default: Any = None,
+) -> Any:
+    logical_path = logical_path.resolve(strict=False)
+    if not collection_storage_path(logical_path).exists() and not logical_path.exists():
+        return default
+    return list(iter_collection(logical_path, legacy_wrapper=legacy_wrapper))
+
+
+def _write_stage_file(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+
+
+def _atomic_replace(source: Path, destination: Path) -> None:
+    source.replace(destination)
+
+
+def _existing_shard_by_prefix(
+    logical_path: Path,
+) -> tuple[Path | None, dict[str, dict[str, Any]]]:
+    if not collection_storage_path(logical_path).exists():
+        return None, {}
+    manifest = validate_collection(logical_path)
+    generation_root, _loaded_manifest = _resolve_current_generation(logical_path)
+    return generation_root, {item["prefix"]: item for item in manifest["shards"]}
+
+
+def write_collection(
+    logical_path: Path,
+    records: Iterable[Any],
+    *,
+    key: Callable[[Any], str],
+    authorization: CorpusWriteAuthorization | None = None,
+    max_shard_bytes: int = MAX_SHARD_BYTES,
+    max_shard_records: int = MAX_SHARD_RECORDS,
+) -> dict[str, Any]:
+    if max_shard_bytes <= 0 or max_shard_records <= 0:
+        raise ShardedCollectionError("Shard limits must be positive integers.")
+    if max_shard_bytes > MAX_SHARD_BYTES or max_shard_records > MAX_SHARD_RECORDS:
+        raise ShardedCollectionError("Shard limits may not exceed the collection contract.")
+    logical_path = logical_path.resolve(strict=False)
+    storage_root = collection_storage_path(logical_path)
+    if authorization is not None:
+        from .corpus_store import authorize_additional_corpus_path  # noqa: PLC0415
+
+        authorize_additional_corpus_path(authorization, storage_root)
+
+    prepared = _prepare_records(records, key, max_shard_bytes=max_shard_bytes)
+    buckets = _partition_records(
+        prepared,
+        max_shard_bytes=max_shard_bytes,
+        max_shard_records=max_shard_records,
+    )
+    shard_payloads: dict[str, bytes] = {}
+    shard_entries: list[dict[str, Any]] = []
+    for prefix in sorted(buckets):
+        items = sorted(buckets[prefix], key=lambda item: item["ordinal"])
+        payload = b"".join(item["encoded"] for item in items)
+        shard_payloads[prefix] = payload
+        shard_entries.append(
+            {
+                "prefix": prefix,
+                "path": f"shards/{prefix}.jsonl",
+                "record_count": len(items),
+                "byte_count": len(payload),
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "min_ordinal": items[0]["ordinal"],
+                "max_ordinal": items[-1]["ordinal"],
+            }
+        )
+
+    manifest_core = _manifest_core(
+        logical_path,
+        record_count=len(prepared),
+        shards=shard_entries,
+        max_shard_bytes=max_shard_bytes,
+        max_shard_records=max_shard_records,
+    )
+    generation_id = _generation_id(manifest_core)
+    manifest = {
+        **manifest_core,
+        "generation_id": generation_id,
+    }
+
+    previous_root, previous_shards = _existing_shard_by_prefix(logical_path)
+    generations_root = collection_generations_path(logical_path)
+    generation_root = generations_root / generation_id
+    storage_root.mkdir(parents=True, exist_ok=True)
+    generations_root.mkdir(parents=True, exist_ok=True)
+    if generation_root.exists():
+        existing_manifest = validate_collection_generation(logical_path, generation_root)
+        if existing_manifest != manifest:
+            raise ShardedCollectionError(
+                f"Existing immutable generation does not match content: {generation_root}"
+            )
+    else:
+        stage_root = generations_root / f".stage-{uuid.uuid4().hex}"
+        try:
+            for entry in shard_entries:
+                prefix = entry["prefix"]
+                stage_path = stage_root / entry["path"]
+                previous = previous_shards.get(prefix)
+                previous_path = (
+                    previous_root / previous["path"]
+                    if previous_root is not None and previous is not None
+                    else None
+                )
+                if (
+                    previous_path is not None
+                    and previous.get("sha256") == entry["sha256"]
+                    and previous_path.is_file()
+                ):
+                    stage_path.parent.mkdir(parents=True, exist_ok=True)
+                    try:
+                        stage_path.hardlink_to(previous_path)
+                    except OSError:
+                        shutil.copyfile(previous_path, stage_path)
+                else:
+                    _write_stage_file(stage_path, shard_payloads[prefix])
+            _write_stage_file(
+                stage_root / "manifest.json",
+                canonical_json_bytes(manifest) + b"\n",
+            )
+            validate_collection_generation(logical_path, stage_root)
+            _atomic_replace(stage_root, generation_root)
+        except Exception:
+            if stage_root.exists():
+                shutil.rmtree(stage_root)
+            raise
+
+    current_path = collection_current_path(logical_path)
+    if current_path.exists() and current_path.read_text(encoding="utf-8").strip() == generation_id:
+        validate_collection(logical_path)
+        return manifest
+
+    current_temp = storage_root / f".CURRENT-{uuid.uuid4().hex}"
+    try:
+        current_temp.write_text(f"{generation_id}\n", encoding="utf-8")
+        _atomic_replace(current_temp, current_path)
+    finally:
+        if current_temp.exists():
+            current_temp.unlink()
+    validate_collection(logical_path)
+    return manifest
+
+
+def validate_collection_generation(
+    logical_path: Path,
+    generation_root: Path,
+) -> dict[str, Any]:
+    logical_path = logical_path.resolve(strict=False)
+    manifest = _load_manifest(generation_root / "manifest.json")
+    return _validate_generation(logical_path, generation_root, manifest)
+
+
+def write_corpus_collection(
+    logical_path: Path,
+    records: Iterable[Any],
+    *,
+    authorization: CorpusWriteAuthorization | None = None,
+) -> dict[str, Any]:
+    return write_collection(
+        logical_path,
+        records,
+        key=lambda record: corpus_collection_key(logical_path, record),
+        authorization=authorization,
+    )
+
+
+def iter_corpus_collection(logical_path: Path) -> Iterator[Any]:
+    legacy_wrapper = "threads" if logical_path.name == "semantic-v3-index.json" else None
+    return iter_collection(logical_path, legacy_wrapper=legacy_wrapper)
+
+
+def load_corpus_collection(logical_path: Path, *, default: Any = None) -> Any:
+    legacy_wrapper = "threads" if logical_path.name == "semantic-v3-index.json" else None
+    return load_collection(
+        logical_path,
+        legacy_wrapper=legacy_wrapper,
+        default=default,
+    )

--- a/tests/test_chatgpt_exporter_to_bundle.py
+++ b/tests/test_chatgpt_exporter_to_bundle.py
@@ -21,6 +21,7 @@ from chatgpt_exporter_to_bundle import (  # noqa: E402
 from conversation_corpus_engine.import_chatgpt_export_corpus import (  # noqa: E402
     import_chatgpt_export_corpus,
 )
+from conversation_corpus_engine.sharded_collection import collection_storage_path  # noqa: E402
 
 
 def _exporter_doc(title: str, link: str, messages: list[dict]) -> dict:
@@ -227,8 +228,12 @@ class EndToEndIntegrationTests(unittest.TestCase):
             self.assertEqual(result["thread_count"], 1)
             self.assertGreaterEqual(result["pair_count"], 1)
             # Federation artifacts produced
-            self.assertTrue((output / "corpus" / "threads-index.json").exists())
-            self.assertTrue((output / "corpus" / "pairs-index.json").exists())
+            self.assertTrue(
+                collection_storage_path(output / "corpus" / "threads-index.json").exists()
+            )
+            self.assertTrue(
+                collection_storage_path(output / "corpus" / "pairs-index.json").exists()
+            )
             self.assertTrue((output / "corpus" / "contract.json").exists())
 
 

--- a/tests/test_claude_code_to_bundle.py
+++ b/tests/test_claude_code_to_bundle.py
@@ -20,6 +20,7 @@ from claude_code_to_bundle import (  # noqa: E402
 from conversation_corpus_engine.import_chatgpt_export_corpus import (  # noqa: E402
     import_chatgpt_export_corpus,
 )
+from conversation_corpus_engine.sharded_collection import collection_storage_path  # noqa: E402
 
 SESSION_A = "aaaaaaaa-1111-2222-3333-444444444444"
 SESSION_B = "bbbbbbbb-5555-6666-7777-888888888888"
@@ -390,8 +391,12 @@ class EndToEndIntegrationTests(unittest.TestCase):
             self.assertEqual(result["thread_count"], 1)
             self.assertGreaterEqual(result["pair_count"], 1)
             # Federation artifacts produced
-            self.assertTrue((output / "corpus" / "threads-index.json").exists())
-            self.assertTrue((output / "corpus" / "pairs-index.json").exists())
+            self.assertTrue(
+                collection_storage_path(output / "corpus" / "threads-index.json").exists()
+            )
+            self.assertTrue(
+                collection_storage_path(output / "corpus" / "pairs-index.json").exists()
+            )
             self.assertTrue((output / "corpus" / "contract.json").exists())
 
 

--- a/tests/test_federated_canon.py
+++ b/tests/test_federated_canon.py
@@ -8,6 +8,7 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from conversation_corpus_engine import federated_canon as MODULE
+from conversation_corpus_engine.sharded_collection import load_corpus_collection
 
 
 def _write_json(path: Path, payload: Any) -> None:
@@ -180,11 +181,12 @@ def test_build_federated_canon_merges_records_from_accepted_decisions(tmp_path: 
 
     result = MODULE.build_federated_canon(project_root, [alpha_surface, beta_surface])
 
-    canonical_families = json.loads(Path(result["canonical_families_path"]).read_text())
-    canonical_entities = json.loads(Path(result["canonical_entities_path"]).read_text())
-    canonical_actions = json.loads(Path(result["canonical_actions_path"]).read_text())
-    canonical_unresolved = json.loads(Path(result["canonical_unresolved_path"]).read_text())
-    lineage_map = json.loads(Path(result["lineage_map_path"]).read_text())
+    federation_root = project_root / "federation"
+    canonical_families = load_corpus_collection(federation_root / "canonical-families.json")
+    canonical_entities = load_corpus_collection(federation_root / "canonical-entities.json")
+    canonical_actions = load_corpus_collection(federation_root / "canonical-actions.json")
+    canonical_unresolved = load_corpus_collection(federation_root / "canonical-unresolved.json")
+    lineage_map = load_corpus_collection(federation_root / "lineage-map.json")
     conflict_report = json.loads(Path(result["conflict_report_path"]).read_text())
     review_queue = json.loads(Path(result["review_queue_path"]).read_text())
 
@@ -347,7 +349,7 @@ def test_ensure_corpus_contract_manifest_preserves_existing_identity(tmp_path: P
     assert payload["adapter_type"] == "existing-adapter"
     assert payload["corpus_id"] == "existing-corpus-id"
     assert payload["name"] == "Existing Corpus Name"
-    assert payload["required_files"] == list(MODULE.CORE_CONTRACT_FILES)
+    assert payload["required_files"] == list(MODULE.LEGACY_CORE_CONTRACT_FILES)
     assert payload["counts"] == {
         "threads": 2,
         "families": 3,

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from conversation_corpus_engine import federated_canon as FED_CANON
 from conversation_corpus_engine import federation as MODULE
+from conversation_corpus_engine.sharded_collection import load_corpus_collection
 
 
 def token_map(*tokens: str) -> dict[str, float]:
@@ -246,14 +247,14 @@ class MemoryFederationTests(unittest.TestCase):
                 project_root, second_root, corpus_id="notes-memory", name="Notes Memory"
             )
             result = MODULE.build_federation(project_root)
-            corpora_summary = json.loads(
-                (project_root / "federation" / "corpora-summary.json").read_text()
+            corpora_summary = load_corpus_collection(
+                project_root / "federation" / "corpora-summary.json"
             )
-            families_index = json.loads(
-                (project_root / "federation" / "families-index.json").read_text()
+            families_index = load_corpus_collection(
+                project_root / "federation" / "families-index.json"
             )
-            canonical_families = json.loads(
-                (project_root / "federation" / "canonical-families.json").read_text()
+            canonical_families = load_corpus_collection(
+                project_root / "federation" / "canonical-families.json"
             )
 
             self.assertTrue(Path(result["summary_markdown_path"]).exists())

--- a/tests/test_import_chatgpt_export_corpus.py
+++ b/tests/test_import_chatgpt_export_corpus.py
@@ -14,6 +14,10 @@ from conversation_corpus_engine.import_chatgpt_export_corpus import (  # noqa: E
     import_chatgpt_export_corpus,
 )
 from conversation_corpus_engine.provider_exports import looks_like_chatgpt_export  # noqa: E402
+from conversation_corpus_engine.sharded_collection import (  # noqa: E402
+    collection_storage_path,
+    load_corpus_collection,
+)
 
 FIXTURE_ROOT = Path(__file__).resolve().parent / "fixtures" / "chatgpt-export"
 
@@ -58,15 +62,15 @@ class ImportChatGPTExportCorpusTests(unittest.TestCase):
                 (output_root / "corpus" / "contract.json").read_text(encoding="utf-8"),
             )
             self.assertEqual(contract["adapter_type"], "chatgpt-export")
-            self.assertEqual(contract["contract_name"], "conversation-corpus-engine-v1")
+            self.assertEqual(contract["contract_name"], "conversation-corpus-engine.v2")
 
             # Verify federation-required files exist
             corpus_dir = output_root / "corpus"
             for required in (
-                "threads-index.json",
-                "pairs-index.json",
-                "doctrine-briefs.json",
-                "canonical-families.json",
+                "threads-index.collection",
+                "pairs-index.collection",
+                "doctrine-briefs.collection",
+                "canonical-families.collection",
                 "evaluation-summary.json",
                 "regression-gates.json",
             ):
@@ -84,9 +88,7 @@ class ImportChatGPTExportCorpusTests(unittest.TestCase):
                 corpus_id="chatgpt-memory",
                 name="ChatGPT Memory",
             )
-            threads = json.loads(
-                (output_root / "corpus" / "threads-index.json").read_text(encoding="utf-8"),
-            )
+            threads = load_corpus_collection(output_root / "corpus" / "threads-index.json")
             # At least one thread should exist even from the null-title conversation
             titles = [t["title_normalized"] for t in threads]
             # The null-title conversation should have an inferred title
@@ -421,8 +423,16 @@ class ImportMultiPartCorpusTests(unittest.TestCase):
             self.assertEqual(result["thread_count"], 3, "Expected 3 unique threads after dedup")
 
             # Sources copied under prefixed subdirectories
-            self.assertTrue((output / "source" / "part-1" / "conversations.json").exists())
-            self.assertTrue((output / "source" / "part-2" / "conversations.json").exists())
+            self.assertTrue(
+                collection_storage_path(
+                    output / "source" / "part-1" / "conversations.json"
+                ).exists()
+            )
+            self.assertTrue(
+                collection_storage_path(
+                    output / "source" / "part-2" / "conversations.json"
+                ).exists()
+            )
 
             # README mentions multi-part
             readme_text = (output / "README.md").read_text(encoding="utf-8")
@@ -444,7 +454,9 @@ class ImportMultiPartCorpusTests(unittest.TestCase):
             self.assertEqual(result["bundle_part_count"], 1)
             self.assertEqual(result["duplicate_conversations_skipped"], 0)
             # Source files at top level of source/, NOT under source/<name>/
-            self.assertTrue((output / "source" / "conversations.json").exists())
+            self.assertTrue(
+                collection_storage_path(output / "source" / "conversations.json").exists()
+            )
             self.assertFalse((output / "source" / "export").exists())
 
 

--- a/tests/test_import_chatgpt_local_session_corpus.py
+++ b/tests/test_import_chatgpt_local_session_corpus.py
@@ -9,6 +9,10 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from conversation_corpus_engine import import_chatgpt_local_session_corpus as module  # noqa: E402
+from conversation_corpus_engine.sharded_collection import (  # noqa: E402
+    collection_storage_path,
+    load_collection,
+)
 
 
 def test_write_local_session_bundle_writes_expected_files(tmp_path: Path) -> None:
@@ -62,10 +66,10 @@ def test_write_local_session_bundle_writes_expected_files(tmp_path: Path) -> Non
     )
 
     assert (bundle_root / "user.json").exists()
-    assert (bundle_root / "conversations.json").exists()
+    assert collection_storage_path(bundle_root / "conversations.json").exists()
     user = json.loads((bundle_root / "user.json").read_text(encoding="utf-8"))
     assert user["email"] == "user@example.com"
-    conversations = json.loads((bundle_root / "conversations.json").read_text(encoding="utf-8"))
+    conversations = load_collection(bundle_root / "conversations.json")
     assert len(conversations) == 1
     assert conversations[0]["conversation_id"] == "conv-1"
 

--- a/tests/test_import_claude_export_corpus.py
+++ b/tests/test_import_claude_export_corpus.py
@@ -14,6 +14,10 @@ from conversation_corpus_engine.import_claude_export_corpus import (  # noqa: E4
     extract_message_text,
     import_claude_export_corpus,
 )
+from conversation_corpus_engine.sharded_collection import (  # noqa: E402
+    collection_storage_path,
+    load_corpus_collection,
+)
 
 
 class ImportClaudeExportCorpusTests(unittest.TestCase):
@@ -102,9 +106,7 @@ class ImportClaudeExportCorpusTests(unittest.TestCase):
             self.assertEqual(contract["adapter_type"], "claude-export")
             self.assertEqual(contract["counts"]["threads"], 1)
             self.assertTrue((output_root / "corpus" / "source-snapshot.json").exists())
-            threads = json.loads(
-                (output_root / "corpus" / "threads-index.json").read_text(encoding="utf-8")
-            )
+            threads = load_corpus_collection(output_root / "corpus" / "threads-index.json")
             self.assertEqual(threads[0]["title_normalized"], "Claude Test Thread")
             self.assertIn("claude-export", threads[0]["tags"])
             readme = (output_root / "README.md").read_text(encoding="utf-8")
@@ -204,12 +206,8 @@ class ImportClaudeExportCorpusTests(unittest.TestCase):
             contract = json.loads(
                 (output_root / "corpus" / "contract.json").read_text(encoding="utf-8")
             )
-            audits = json.loads(
-                (output_root / "corpus" / "import-audit.json").read_text(encoding="utf-8")
-            )
-            duplicates = json.loads(
-                (output_root / "corpus" / "near-duplicates.json").read_text(encoding="utf-8")
-            )
+            audits = load_corpus_collection(output_root / "corpus" / "import-audit.json")
+            duplicates = load_corpus_collection(output_root / "corpus" / "near-duplicates.json")
 
             self.assertEqual(result["near_duplicate_count"], 1)
             self.assertEqual(contract["counts"]["near_duplicates"], 1)
@@ -447,8 +445,16 @@ class ImportMultiPartCorpusTests(unittest.TestCase):
             self.assertEqual(result["duplicate_conversations_skipped"], 1)
             self.assertEqual(result["thread_count"], 3, "Expected 3 unique threads after dedup")
 
-            self.assertTrue((output / "source" / "part-1" / "conversations.json").exists())
-            self.assertTrue((output / "source" / "part-2" / "conversations.json").exists())
+            self.assertTrue(
+                collection_storage_path(
+                    output / "source" / "part-1" / "conversations.json"
+                ).exists()
+            )
+            self.assertTrue(
+                collection_storage_path(
+                    output / "source" / "part-2" / "conversations.json"
+                ).exists()
+            )
 
             readme_text = (output / "README.md").read_text(encoding="utf-8")
             self.assertIn("Bundle parts: 2", readme_text)
@@ -464,7 +470,9 @@ class ImportMultiPartCorpusTests(unittest.TestCase):
 
             self.assertEqual(result["bundle_part_count"], 1)
             self.assertEqual(result["duplicate_conversations_skipped"], 0)
-            self.assertTrue((output / "source" / "conversations.json").exists())
+            self.assertTrue(
+                collection_storage_path(output / "source" / "conversations.json").exists()
+            )
             self.assertFalse((output / "source" / "export").exists())
 
 

--- a/tests/test_import_document_export_corpus.py
+++ b/tests/test_import_document_export_corpus.py
@@ -10,6 +10,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from conversation_corpus_engine.import_document_export_corpus import import_document_export_corpus
+from conversation_corpus_engine.sharded_collection import load_corpus_collection
 
 
 class ImportDocumentExportCorpusTests(unittest.TestCase):
@@ -47,9 +48,7 @@ class ImportDocumentExportCorpusTests(unittest.TestCase):
             snapshot = json.loads(
                 (output_root / "corpus" / "source-snapshot.json").read_text(encoding="utf-8")
             )
-            manifest = json.loads(
-                (output_root / "import-manifest.json").read_text(encoding="utf-8")
-            )
+            manifest = load_corpus_collection(output_root / "import-manifest.json")
 
             self.assertEqual(contract["adapter_type"], "perplexity-export")
             self.assertEqual(contract["corpus_id"], "perplexity-history-memory")

--- a/tests/test_import_markdown_document_corpus.py
+++ b/tests/test_import_markdown_document_corpus.py
@@ -11,6 +11,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from conversation_corpus_engine.import_markdown_document_corpus import (
     import_markdown_document_corpus,
 )
+from conversation_corpus_engine.sharded_collection import (
+    collection_storage_path,
+    load_corpus_collection,
+)
 
 
 class ImportMarkdownDocumentCorpusTests(unittest.TestCase):
@@ -36,11 +40,14 @@ class ImportMarkdownDocumentCorpusTests(unittest.TestCase):
             )
 
             self.assertEqual(result["thread_count"], 1)
-            self.assertTrue((output_root / "corpus" / "threads-index.json").exists())
-            self.assertTrue((output_root / "corpus" / "semantic-v3-index.json").exists())
-            self.assertTrue((output_root / "corpus" / "pairs-index.json").exists())
-            self.assertTrue((output_root / "corpus" / "doctrine-briefs.json").exists())
-            self.assertTrue((output_root / "corpus" / "family-dossiers.json").exists())
+            for filename in (
+                "threads-index.json",
+                "semantic-v3-index.json",
+                "pairs-index.json",
+                "doctrine-briefs.json",
+                "family-dossiers.json",
+            ):
+                self.assertTrue(collection_storage_path(output_root / "corpus" / filename).exists())
             self.assertTrue((output_root / "corpus" / "contract.json").exists())
             self.assertTrue((output_root / "corpus" / "source-snapshot.json").exists())
             self.assertTrue((output_root / "corpus" / "regression-gates.json").exists())
@@ -51,12 +58,8 @@ class ImportMarkdownDocumentCorpusTests(unittest.TestCase):
             self.assertEqual(contract["adapter_type"], "markdown-document")
             self.assertTrue(contract["source_signature_fingerprint"])
 
-            actions = json.loads(
-                (output_root / "corpus" / "action-ledger.json").read_text(encoding="utf-8")
-            )
-            unresolved = json.loads(
-                (output_root / "corpus" / "unresolved-ledger.json").read_text(encoding="utf-8")
-            )
+            actions = load_corpus_collection(output_root / "corpus" / "action-ledger.json")
+            unresolved = load_corpus_collection(output_root / "corpus" / "unresolved-ledger.json")
             self.assertGreaterEqual(len(actions), 1)
             self.assertGreaterEqual(len(unresolved), 1)
 
@@ -81,9 +84,7 @@ class ImportMarkdownDocumentCorpusTests(unittest.TestCase):
             )
 
             self.assertEqual(result["thread_count"], 1)
-            manifest = json.loads(
-                (output_root / "import-manifest.json").read_text(encoding="utf-8")
-            )
+            manifest = load_corpus_collection(output_root / "import-manifest.json")
             self.assertEqual(len(manifest), 1)
             self.assertIn("TopLevel.md", manifest[0]["source_markdown"])
 
@@ -118,15 +119,9 @@ class ImportMarkdownDocumentCorpusTests(unittest.TestCase):
 
             import_markdown_document_corpus(input_root, output_root, corpus_id="document-memory")
 
-            actions = json.loads(
-                (output_root / "corpus" / "action-ledger.json").read_text(encoding="utf-8")
-            )
-            unresolved = json.loads(
-                (output_root / "corpus" / "unresolved-ledger.json").read_text(encoding="utf-8")
-            )
-            threads = json.loads(
-                (output_root / "corpus" / "threads-index.json").read_text(encoding="utf-8")
-            )
+            actions = load_corpus_collection(output_root / "corpus" / "action-ledger.json")
+            unresolved = load_corpus_collection(output_root / "corpus" / "unresolved-ledger.json")
+            threads = load_corpus_collection(output_root / "corpus" / "threads-index.json")
 
             self.assertEqual(len(actions), 1)
             self.assertEqual(

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -8,8 +8,14 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+from conversation_corpus_engine.corpus_store import register_corpus_store
 from conversation_corpus_engine.federation import list_registered_corpora
-from conversation_corpus_engine.migration import seed_registry_from_staging
+from conversation_corpus_engine.migration import migrate_corpus_v2, seed_registry_from_staging
+from conversation_corpus_engine.sharded_collection import (
+    collection_current_path,
+    collection_storage_path,
+    load_corpus_collection,
+)
 
 
 def seed_valid_corpus(root: Path, *, contract_name: str = "conversation-corpus-engine-v1") -> None:
@@ -37,6 +43,9 @@ def seed_valid_corpus(root: Path, *, contract_name: str = "conversation-corpus-e
                 "contract_name": contract_name,
                 "contract_version": 1,
                 "adapter_type": "markdown-document",
+                "corpus_id": root.name,
+                "name": root.name.replace("-", " ").title(),
+                "generated_at": "2026-07-23T00:00:00+00:00",
             }
         ),
         encoding="utf-8",
@@ -59,6 +68,113 @@ class MigrationTests(unittest.TestCase):
             self.assertEqual(len(corpora), 2)
             self.assertEqual(corpora[0]["corpus_id"], "chatgpt-history")
             self.assertTrue(any(entry["default"] for entry in corpora))
+
+    def test_corpus_v2_migration_is_read_only_by_default_and_idempotent_on_write(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            project_root = root / "project"
+            source_root = root / "legacy"
+            store_root = root / "store"
+            destination_root = store_root / "migrated"
+            project_root.mkdir()
+            store_root.mkdir()
+            seed_valid_corpus(source_root)
+            (source_root / "corpus" / "threads-index.json").write_text(
+                json.dumps([{"thread_uid": "thread-1", "title_normalized": "One"}]),
+                encoding="utf-8",
+            )
+            (source_root / "source").mkdir()
+            (source_root / "source" / "conversations.json").write_text(
+                json.dumps([{"conversation_id": "conversation-1", "title": "One"}]),
+                encoding="utf-8",
+            )
+            multipart_source = source_root / "source" / "part-2"
+            multipart_source.mkdir()
+            (multipart_source / "conversations.json").write_text(
+                json.dumps([{"conversation_id": "conversation-2", "title": "Two"}]),
+                encoding="utf-8",
+            )
+            (source_root / "corpus" / "action-ledger.json").write_text(
+                json.dumps(
+                    [
+                        {
+                            "action_key": "action-shared",
+                            "canonical_action": "Ship the migration.",
+                            "family_ids": ["family-1"],
+                            "thread_uids": ["thread-1"],
+                            "occurrence_count": 1,
+                        },
+                        {
+                            "action_key": "action-shared",
+                            "canonical_action": "Ship the migration.",
+                            "family_ids": ["family-2"],
+                            "thread_uids": ["thread-2"],
+                            "occurrence_count": 1,
+                        },
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            source_bytes = (source_root / "corpus" / "threads-index.json").read_bytes()
+            register_corpus_store(project_root, store_root)
+
+            dry_run = migrate_corpus_v2(
+                project_root=project_root,
+                source_root=source_root,
+                destination_root=destination_root,
+                corpus_store_root=store_root,
+            )
+            self.assertEqual(dry_run["mode"], "read-only")
+            self.assertFalse(destination_root.exists())
+
+            first = migrate_corpus_v2(
+                project_root=project_root,
+                source_root=source_root,
+                destination_root=destination_root,
+                corpus_store_root=store_root,
+                write=True,
+            )
+            pointer_before = collection_current_path(
+                destination_root / "corpus" / "threads-index.json"
+            ).read_text(encoding="utf-8")
+            second = migrate_corpus_v2(
+                project_root=project_root,
+                source_root=source_root,
+                destination_root=destination_root,
+                corpus_store_root=store_root,
+                write=True,
+            )
+            pointer_after = collection_current_path(
+                destination_root / "corpus" / "threads-index.json"
+            ).read_text(encoding="utf-8")
+
+            self.assertEqual(first["generation_ids"], second["generation_ids"])
+            self.assertTrue(first["contract_validation"]["valid"])
+            self.assertEqual(pointer_before, pointer_after)
+            self.assertEqual(
+                load_corpus_collection(destination_root / "corpus" / "threads-index.json"),
+                [{"thread_uid": "thread-1", "title_normalized": "One"}],
+            )
+            self.assertTrue(
+                collection_storage_path(destination_root / "source" / "conversations.json").exists()
+            )
+            self.assertTrue(
+                collection_storage_path(
+                    destination_root / "source" / "part-2" / "conversations.json"
+                ).exists()
+            )
+            self.assertFalse((destination_root / "source" / "conversations.json").exists())
+            self.assertEqual(
+                (source_root / "corpus" / "threads-index.json").read_bytes(),
+                source_bytes,
+            )
+            migrated_actions = load_corpus_collection(
+                destination_root / "corpus" / "action-ledger.json"
+            )
+            self.assertEqual(len(migrated_actions), 1)
+            self.assertEqual(migrated_actions[0]["occurrence_count"], 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -52,6 +52,7 @@ class SchemaValidationTests(unittest.TestCase):
                 "near-duplicates",
                 "promotion-policy",
                 "provider-refresh",
+                "sharded-collection",
                 "source-policy",
                 "surface-bundle",
                 "surface-manifest",

--- a/tests/test_sharded_collection.py
+++ b/tests/test_sharded_collection.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from conversation_corpus_engine.schema_validation import validate_payload
+from conversation_corpus_engine.sharded_collection import (
+    SHARDED_COLLECTION_CONTRACT,
+    ShardedCollectionError,
+    collection_current_path,
+    collection_generations_path,
+    collection_storage_path,
+    iter_collection,
+    load_collection,
+    validate_collection,
+    write_collection,
+)
+
+
+def record_key(record: dict[str, object]) -> str:
+    return str(record["id"])
+
+
+def generation_root(logical_path: Path, generation_id: str) -> Path:
+    return collection_generations_path(logical_path) / generation_id
+
+
+def keys_with_shared_prefix(count: int) -> list[str]:
+    by_prefix: dict[str, list[str]] = {}
+    candidate = 0
+    while True:
+        key = f"key-{candidate}"
+        prefix = hashlib.sha256(key.encode()).hexdigest()[:2]
+        matches = by_prefix.setdefault(prefix, [])
+        matches.append(key)
+        if len(matches) == count:
+            return matches
+        candidate += 1
+
+
+def test_ordered_round_trip_and_deterministic_rerun(tmp_path: Path) -> None:
+    logical_path = tmp_path / "threads-index.json"
+    records = [{"id": f"record-{index:03d}", "value": index} for index in range(50)]
+
+    first = write_collection(logical_path, records, key=record_key)
+    first_current = collection_current_path(logical_path).read_bytes()
+    first_generation_dirs = sorted(collection_generations_path(logical_path).iterdir())
+    second = write_collection(logical_path, records, key=record_key)
+
+    assert first["contract_name"] == SHARDED_COLLECTION_CONTRACT
+    assert second == first
+    assert list(iter_collection(logical_path)) == records
+    assert load_collection(logical_path) == records
+    assert collection_current_path(logical_path).read_bytes() == first_current
+    assert sorted(collection_generations_path(logical_path).iterdir()) == first_generation_dirs
+    assert not logical_path.exists()
+    assert validate_collection(logical_path) == first
+    assert validate_payload("sharded-collection", first)["valid"] is True
+
+
+def test_recursive_prefix_splitting_honors_limits(tmp_path: Path) -> None:
+    logical_path = tmp_path / "pairs-index.json"
+    keys = keys_with_shared_prefix(3)
+    records = [{"id": key, "payload": "small"} for key in keys]
+
+    manifest = write_collection(
+        logical_path,
+        records,
+        key=record_key,
+        max_shard_bytes=1_024,
+        max_shard_records=1,
+    )
+
+    assert load_collection(logical_path) == records
+    assert all(item["record_count"] == 1 for item in manifest["shards"])
+    assert all(item["byte_count"] <= 1_024 for item in manifest["shards"])
+    assert any(len(item["prefix"]) > 2 for item in manifest["shards"])
+
+
+def test_duplicate_or_oversized_record_never_changes_current(tmp_path: Path) -> None:
+    logical_path = tmp_path / "threads-index.json"
+    baseline = [{"id": "baseline", "payload": "safe"}]
+    write_collection(logical_path, baseline, key=record_key, max_shard_bytes=200)
+    before = collection_current_path(logical_path).read_bytes()
+
+    with pytest.raises(ShardedCollectionError, match="Duplicate"):
+        write_collection(
+            logical_path,
+            [{"id": "duplicate"}, {"id": "duplicate"}],
+            key=record_key,
+            max_shard_bytes=200,
+        )
+    with pytest.raises(ShardedCollectionError, match="exceeds"):
+        write_collection(
+            logical_path,
+            [{"id": "oversized", "payload": "x" * 500}],
+            key=record_key,
+            max_shard_bytes=200,
+        )
+
+    assert collection_current_path(logical_path).read_bytes() == before
+    assert load_collection(logical_path) == baseline
+
+
+def test_limits_cannot_exceed_the_published_contract(tmp_path: Path) -> None:
+    logical_path = tmp_path / "threads-index.json"
+
+    with pytest.raises(ShardedCollectionError, match="may not exceed"):
+        write_collection(
+            logical_path,
+            [{"id": "record"}],
+            key=record_key,
+            max_shard_bytes=(8 * 1024 * 1024) + 1,
+        )
+    with pytest.raises(ShardedCollectionError, match="may not exceed"):
+        write_collection(
+            logical_path,
+            [{"id": "record"}],
+            key=record_key,
+            max_shard_records=1_001,
+        )
+
+    assert not collection_storage_path(logical_path).exists()
+
+
+@pytest.mark.parametrize(
+    "failure",
+    ["missing", "corrupt", "duplicate-catalog", "unlisted", "path-traversal"],
+)
+def test_missing_corrupt_or_duplicate_shard_state_fails_closed(
+    tmp_path: Path,
+    failure: str,
+) -> None:
+    logical_path = tmp_path / f"{failure}.json"
+    manifest = write_collection(
+        logical_path,
+        [{"id": "alpha"}, {"id": "beta"}],
+        key=record_key,
+    )
+    root = generation_root(logical_path, manifest["generation_id"])
+    manifest_path = root / "manifest.json"
+    first_shard = root / manifest["shards"][0]["path"]
+
+    if failure == "missing":
+        first_shard.unlink()
+    elif failure == "corrupt":
+        first_shard.write_bytes(first_shard.read_bytes() + b"{}\n")
+    elif failure == "duplicate-catalog":
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        payload["shards"].append(dict(payload["shards"][0]))
+        manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    elif failure == "unlisted":
+        (root / "shards" / "extra.jsonl").write_text("{}\n", encoding="utf-8")
+    else:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        payload["shards"][0]["path"] = "shards/../../outside.jsonl"
+        manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ShardedCollectionError):
+        load_collection(logical_path)
+
+
+def test_incomplete_v2_state_never_falls_back_to_v1(tmp_path: Path) -> None:
+    logical_path = tmp_path / "threads-index.json"
+    logical_path.write_text('[{"id":"legacy"}]\n', encoding="utf-8")
+    collection_storage_path(logical_path).mkdir()
+
+    with pytest.raises(ShardedCollectionError, match="CURRENT"):
+        load_collection(logical_path)
+
+
+def test_interrupted_publication_preserves_previous_current(tmp_path: Path) -> None:
+    logical_path = tmp_path / "threads-index.json"
+    baseline = [{"id": "alpha", "value": 1}]
+    write_collection(logical_path, baseline, key=record_key)
+    before = collection_current_path(logical_path).read_bytes()
+    original_replace = Path.replace
+
+    def interrupt_current(source: Path, destination: Path) -> None:
+        if destination == collection_current_path(logical_path):
+            raise OSError("simulated publication interruption")
+        original_replace(source, destination)
+
+    with (
+        patch(
+            "conversation_corpus_engine.sharded_collection._atomic_replace",
+            side_effect=interrupt_current,
+        ),
+        pytest.raises(OSError, match="interruption"),
+    ):
+        write_collection(
+            logical_path,
+            [{"id": "alpha", "value": 2}],
+            key=record_key,
+        )
+
+    assert collection_current_path(logical_path).read_bytes() == before
+    assert load_collection(logical_path) == baseline
+
+
+def test_v1_array_and_wrapped_collection_compatibility(tmp_path: Path) -> None:
+    array_path = tmp_path / "threads-index.json"
+    wrapped_path = tmp_path / "semantic-v3-index.json"
+    records = [{"id": "legacy"}]
+    array_path.write_text(json.dumps(records), encoding="utf-8")
+    wrapped_path.write_text(json.dumps({"threads": records}), encoding="utf-8")
+
+    assert load_collection(array_path) == records
+    assert load_collection(wrapped_path, legacy_wrapper="threads") == records
+
+
+def test_one_record_change_reuses_every_unchanged_shard(tmp_path: Path) -> None:
+    logical_path = tmp_path / "threads-index.json"
+    keys = []
+    prefixes: set[str] = set()
+    candidate = 0
+    while len(keys) < 2:
+        key = f"locality-{candidate}"
+        prefix = hashlib.sha256(key.encode()).hexdigest()[:2]
+        if prefix not in prefixes:
+            prefixes.add(prefix)
+            keys.append(key)
+        candidate += 1
+    baseline = [{"id": keys[0], "value": 1}, {"id": keys[1], "value": 2}]
+    first = write_collection(logical_path, baseline, key=record_key)
+    changed = [{"id": keys[0], "value": 99}, {"id": keys[1], "value": 2}]
+    second = write_collection(logical_path, changed, key=record_key)
+    first_root = generation_root(logical_path, first["generation_id"])
+    second_root = generation_root(logical_path, second["generation_id"])
+    first_by_prefix = {item["prefix"]: item for item in first["shards"]}
+    second_by_prefix = {item["prefix"]: item for item in second["shards"]}
+    unchanged_prefixes = {
+        prefix
+        for prefix in first_by_prefix
+        if first_by_prefix[prefix]["sha256"] == second_by_prefix[prefix]["sha256"]
+    }
+    changed_prefixes = set(first_by_prefix) - unchanged_prefixes
+
+    assert len(changed_prefixes) == 1
+    assert len(unchanged_prefixes) == 1
+    for prefix in unchanged_prefixes:
+        first_path = first_root / first_by_prefix[prefix]["path"]
+        second_path = second_root / second_by_prefix[prefix]["path"]
+        assert first_path.stat().st_ino == second_path.stat().st_ino
+    assert load_collection(logical_path) == changed


### PR DESCRIPTION
## Summary

- publish corpus and federation collections as immutable `conversation-corpus-engine.v2` / `cce.sharded_collection.v1` generations
- enforce canonical keyed JSONL shards, recursive SHA-256 prefix partitioning, 8 MiB / 1,000-record ceilings, full manifest and shard verification, fail-closed v2 reads, shard reuse, and atomic `CURRENT` publication
- retain v1 read compatibility only when no v2 state exists and convert imports, answering, federation, evaluation, corpus diff, persona extraction, and federated canon consumers
- add a read-only-by-default `cce migration corpus-v2` command with authorized `--write`, source preservation, v1 ledger normalization, source-conversation sharding, and deterministic reruns
- publish the sharded collection schema and document the physical contract

## Safety boundary

No real corpus was read, hashed, copied, migrated, or deleted. All storage and migration proofs use temporary synthetic fixtures. Draft PR #62 is untouched.

## Verification

- 392 repository tests passed in scoped per-file runs
- focused Python 3.13 sharded-storage and migration tests passed
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- schema catalog load check
- `git diff --check`

Closes #36