### PR TITLE
feat: CCE→aps brainstorm bridge + Perplexity local-session capture

### DIFF
--- a/src/conversation_corpus_engine/aps_bridge.py
+++ b/src/conversation_corpus_engine/aps_bridge.py
@@ -1,0 +1,154 @@
+"""CCE → aps brainstorm bridge.
+
+The connector the pipeline was missing: it queries the federated conversation
+corpora (ChatGPT, Claude, Perplexity — whatever is registered) for a subject's
+brainstorm threads and materializes the matches as a markdown notes directory
+that ``aps corpus ingest`` reads as provenance.
+
+Re-runnable by design: run it again after new thinking lands and the notes dir
+refreshes, so a living brainstorm keeps feeding an aps subject rather than being
+pulled once and going stale.
+
+The pulled threads are the owner's IP. This module never chooses where they
+land — the caller passes ``--out`` (canonically an ARCA-sealed ``_*-private``
+store, never a public tree, never gitignored).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import Any
+
+from .answering import search_documents_v4
+
+
+def _slugify(text: str, *, fallback: str = "thread") -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", (text or "").lower()).strip("-")
+    return (slug or fallback)[:80]
+
+
+def gather_hits(
+    corpus_roots: list[Path],
+    queries: list[str],
+    *,
+    limit_per_query: int = 12,
+    min_score: float = 0.0,
+) -> dict[str, dict[str, Any]]:
+    """Union of hits across every (root, query), deduped by thread_uid.
+
+    A thread that matches several queries is kept once, at its highest score,
+    with every matching query recorded so the note shows why it surfaced.
+    """
+    best: dict[str, dict[str, Any]] = {}
+    for root in corpus_roots:
+        corpus_id = root.name
+        for query in queries:
+            result = search_documents_v4(root, query, limit=limit_per_query)
+            for hit in result.get("hits", []):
+                score = float(hit.get("score") or 0.0)
+                if score < min_score:
+                    continue
+                uid = hit.get("thread_uid") or hit.get("doc_id") or hit.get("title")
+                if not uid:
+                    continue
+                existing = best.get(uid)
+                if existing is None:
+                    best[uid] = {
+                        "uid": uid,
+                        "title": hit.get("title") or uid,
+                        "text": hit.get("text") or hit.get("snippet") or "",
+                        "score": score,
+                        "corpus": corpus_id,
+                        "queries": {query},
+                    }
+                else:
+                    existing["queries"].add(query)
+                    if score > existing["score"]:
+                        existing["score"] = score
+                        existing["corpus"] = corpus_id
+                        if len(hit.get("text") or "") > len(existing["text"]):
+                            existing["text"] = hit.get("text") or existing["text"]
+    return best
+
+
+def write_notes(hits: dict[str, dict[str, Any]], out_dir: Path) -> list[Path]:
+    """Write one markdown note per thread plus an index; return files written."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    ordered = sorted(hits.values(), key=lambda h: h["score"], reverse=True)
+    for hit in ordered:
+        name = f"{_slugify(hit['title'])}--{_slugify(hit['uid'], fallback='t')[:12]}.md"
+        path = out_dir / name
+        queries = ", ".join(sorted(hit["queries"]))
+        body = (
+            f"# {hit['title']}\n\n"
+            f"> Source corpus: **{hit['corpus']}** · relevance score: {hit['score']:.1f} · "
+            f"matched query: _{queries}_\n"
+            f"> Thread UID: `{hit['uid']}`\n\n"
+            f"{hit['text'].strip()}\n"
+        )
+        path.write_text(body, encoding="utf-8")
+        written.append(path)
+    index = out_dir / "_brainstorm-index.md"
+    lines = [
+        "# Brainstorm bridge index",
+        "",
+        f"{len(ordered)} threads pulled from the conversation corpora by the CCE→aps bridge.",
+        "Re-run the bridge to refresh; `aps corpus ingest` reads this dir as provenance.",
+        "",
+    ]
+    for hit in ordered:
+        lines.append(f"- **{hit['title']}** — {hit['corpus']} (score {hit['score']:.1f})")
+    index.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    written.append(index)
+    return written
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cce-aps-export",
+        description="Export brainstorm threads from CCE corpora to an aps notes dir.",
+    )
+    parser.add_argument(
+        "--root",
+        dest="roots",
+        action="append",
+        required=True,
+        type=Path,
+        help="A materialized corpus root (repeatable). E.g. chatgpt-local-session-memory.",
+    )
+    parser.add_argument(
+        "--query",
+        dest="queries",
+        action="append",
+        required=True,
+        help="A brainstorm query (repeatable). Threads matching any query are kept.",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        type=Path,
+        help="Output notes directory (an ARCA-sealed private store — never a public tree).",
+    )
+    parser.add_argument("--limit-per-query", type=int, default=12)
+    parser.add_argument("--min-score", type=float, default=0.0)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_argument_parser().parse_args(argv)
+    hits = gather_hits(
+        args.roots,
+        args.queries,
+        limit_per_query=args.limit_per_query,
+        min_score=args.min_score,
+    )
+    written = write_notes(hits, args.out)
+    print(f"cce-aps-export: {len(hits)} threads → {len(written)} files in {args.out}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/conversation_corpus_engine/import_perplexity_local_session_corpus.py
+++ b/src/conversation_corpus_engine/import_perplexity_local_session_corpus.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Import a Perplexity local-session corpus.
+
+Mirrors import_chatgpt_local_session_corpus.py: discovers the Perplexity
+desktop app session via the binary cookie jar, fetches threads through the
+REST API, renders each normalized thread as a markdown document, then
+delegates to the existing document-export import adapter (Perplexity's native
+`document-export` discovery mode) for corpus generation and federation.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from .answering import load_json, slugify, write_json, write_markdown
+from .import_document_export_corpus import import_document_export_corpus
+from .perplexity_local_session import (
+    discover_perplexity_local_session,
+    fetch_perplexity_local_session_bundle,
+    now_iso,
+)
+from .source_lifecycle import build_source_snapshot
+
+DEFAULT_OUTPUT_ROOT = Path.cwd() / "perplexity-local-session-memory"
+DEFAULT_CORPUS_ID = "perplexity-local-session-memory"
+DEFAULT_NAME = "Perplexity Local Session Memory"
+
+
+def render_thread_markdown(thread: dict[str, Any]) -> str:
+    """Render one normalized thread record as a conversation markdown document."""
+    title = thread.get("title_normalized") or thread.get("title_raw") or "Untitled Perplexity Thread"
+    lines = [f"# {title}", ""]
+    url = thread.get("url")
+    if url:
+        lines.extend([f"Source: {url}", ""])
+    for message in thread.get("messages") or []:
+        role = message.get("role", "")
+        text = (message.get("text") or "").strip()
+        if not text:
+            continue
+        label = "User" if role == "user" else "Assistant"
+        lines.extend([f"## {label}", "", text, ""])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_thread_markdown_bundle(bundle_root: Path, bundle: dict[str, Any]) -> int:
+    """Write each thread as a markdown file under ``bundle_root``. Returns count."""
+    bundle_root.mkdir(parents=True, exist_ok=True)
+    written = 0
+    seen: dict[str, int] = {}
+    for thread in bundle.get("threads") or []:
+        if not (thread.get("messages") or []):
+            continue
+        uuid = thread.get("thread_uid") or ""
+        title = thread.get("title_normalized") or thread.get("title_raw") or uuid
+        slug = slugify(title, limit=80) or (uuid[:8] if uuid else "thread")
+        # Disambiguate collisions deterministically (uuid suffix).
+        base = f"{slug}--{uuid[:8]}" if uuid else slug
+        if base in seen:
+            seen[base] += 1
+            base = f"{base}-{seen[base]}"
+        else:
+            seen[base] = 0
+        (bundle_root / f"{base}.md").write_text(
+            render_thread_markdown(thread), encoding="utf-8"
+        )
+        written += 1
+    return written
+
+
+def patch_contract_for_local_session(
+    output_root: Path,
+    *,
+    cookie_jar: Path,
+    discovery: dict[str, Any],
+) -> None:
+    corpus_dir = output_root / "corpus"
+    contract_path = corpus_dir / "contract.json"
+    contract = load_json(contract_path, default={}) or {}
+    source_snapshot = build_source_snapshot(
+        cookie_jar.parent, "perplexity-local-session", "local-session"
+    )
+    contract.update(
+        {
+            "adapter_type": "perplexity-local-session",
+            "source_input": str(cookie_jar),
+            "collection_scope": "local-session",
+            "source_snapshot_path": "corpus/source-snapshot.json",
+            "source_signature_fingerprint": source_snapshot.get("signature_fingerprint"),
+            "source_content_fingerprint": source_snapshot.get("content_fingerprint"),
+            "source_file_count": source_snapshot.get("file_count"),
+            "source_total_bytes": source_snapshot.get("total_bytes"),
+            "source_latest_mtime_ns": source_snapshot.get("latest_mtime_ns"),
+            "local_session": {
+                "discovered_at": discovery.get("generated_at") or now_iso(),
+                "account_id": discovery.get("account_id"),
+                "account_email": discovery.get("account_email"),
+                "account_username": discovery.get("account_username"),
+                "conversation_count": discovery.get("conversation_count"),
+            },
+        },
+    )
+    write_json(corpus_dir / "source-snapshot.json", source_snapshot)
+    write_json(contract_path, contract)
+
+    evaluation_summary = load_json(corpus_dir / "evaluation-summary.json", default={}) or {}
+    evaluation_summary["notes"] = [
+        "Imported Perplexity local-session corpus has not been manually evaluated."
+    ]
+    write_json(corpus_dir / "evaluation-summary.json", evaluation_summary)
+
+    regression_gates = load_json(corpus_dir / "regression-gates.json", default={}) or {}
+    regression_gates["source_notes"] = [
+        "Imported Perplexity local-session corpus has not been manually evaluated."
+    ]
+    write_json(corpus_dir / "regression-gates.json", regression_gates)
+
+
+def rewrite_readme_for_local_session(
+    output_root: Path, *, cookie_jar: Path, bundle: dict[str, Any]
+) -> None:
+    detail_failures = bundle.get("thread_detail_failures") or []
+    write_markdown(
+        output_root / "README.md",
+        "\n".join(
+            [
+                "# Perplexity Local Session Memory Corpus",
+                "",
+                f"- Generated: {now_iso()}",
+                f"- Source input: {cookie_jar}",
+                "- Adapter type: perplexity-local-session",
+                f"- Account: {bundle.get('account_email') or 'unknown'}",
+                f"- Imported threads: {len(bundle.get('threads') or [])}",
+                f"- Detail fetch failures: {len(detail_failures)}",
+                f"- Total available: {bundle.get('total_count', '?')}",
+                f"- Contract manifest: {output_root / 'corpus' / 'contract.json'}",
+                "",
+                "This corpus was imported from the local signed-in Perplexity desktop session.",
+            ],
+        ),
+    )
+
+
+def import_perplexity_local_session_corpus(
+    cookie_jar: Path,
+    output_root: Path,
+    *,
+    corpus_id: str = DEFAULT_CORPUS_ID,
+    name: str = DEFAULT_NAME,
+    limit: int = 50,
+    throttle: float = 0.0,
+) -> dict[str, Any]:
+    cookie_jar = cookie_jar.resolve()
+    output_root = output_root.resolve()
+    discovery = discover_perplexity_local_session(cookie_jar)
+    bundle = fetch_perplexity_local_session_bundle(cookie_jar, limit=limit)
+
+    with tempfile.TemporaryDirectory(prefix="perplexity-local-session-") as tmpdir:
+        bundle_root = Path(tmpdir) / "perplexity-local-bundle"
+        thread_count = write_thread_markdown_bundle(bundle_root, bundle)
+        if thread_count == 0:
+            raise FileNotFoundError(
+                "Perplexity local session did not yield any threads with content to import."
+            )
+        result = import_document_export_corpus(
+            bundle_root,
+            output_root,
+            provider_slug="perplexity",
+            corpus_id=corpus_id,
+            name=name,
+            throttle=throttle,
+        )
+        source_root = output_root / "source"
+        source_root.mkdir(parents=True, exist_ok=True)
+        write_json(source_root / "local-session-discovery.json", discovery)
+        write_json(
+            source_root / "local-session-metadata.json",
+            {
+                "generated_at": bundle.get("generated_at") or now_iso(),
+                "cookie_jar": str(cookie_jar),
+                "account_id": discovery.get("account_id"),
+                "account_email": discovery.get("account_email"),
+                "account_username": discovery.get("account_username"),
+                "detail_failure_count": len(bundle.get("thread_detail_failures") or []),
+                "fetched_count": bundle.get("fetched_count", 0),
+                "total_count": bundle.get("total_count", 0),
+                "acquisition_report": bundle.get("acquisition_report"),
+            },
+        )
+
+    patch_contract_for_local_session(output_root, cookie_jar=cookie_jar, discovery=discovery)
+    rewrite_readme_for_local_session(output_root, cookie_jar=cookie_jar, bundle=bundle)
+
+    result["source_type"] = "perplexity-local-session"
+    result["cookie_jar"] = str(cookie_jar)
+    result["discovery_path"] = str(output_root / "source" / "local-session-discovery.json")
+    result["detail_failure_count"] = len(bundle.get("thread_detail_failures") or [])
+    result["acquisition_report"] = bundle.get("acquisition_report")
+    return result

--- a/src/conversation_corpus_engine/import_perplexity_local_session_corpus.py
+++ b/src/conversation_corpus_engine/import_perplexity_local_session_corpus.py
@@ -30,7 +30,9 @@ DEFAULT_NAME = "Perplexity Local Session Memory"
 
 def render_thread_markdown(thread: dict[str, Any]) -> str:
     """Render one normalized thread record as a conversation markdown document."""
-    title = thread.get("title_normalized") or thread.get("title_raw") or "Untitled Perplexity Thread"
+    title = (
+        thread.get("title_normalized") or thread.get("title_raw") or "Untitled Perplexity Thread"
+    )
     lines = [f"# {title}", ""]
     url = thread.get("url")
     if url:
@@ -63,9 +65,7 @@ def write_thread_markdown_bundle(bundle_root: Path, bundle: dict[str, Any]) -> i
             base = f"{base}-{seen[base]}"
         else:
             seen[base] = 0
-        (bundle_root / f"{base}.md").write_text(
-            render_thread_markdown(thread), encoding="utf-8"
-        )
+        (bundle_root / f"{base}.md").write_text(render_thread_markdown(thread), encoding="utf-8")
         written += 1
     return written
 

--- a/src/conversation_corpus_engine/perplexity_local_session.py
+++ b/src/conversation_corpus_engine/perplexity_local_session.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""Perplexity local-session client.
+
+Reads cookies from the Perplexity macOS desktop app's binary cookie jar
+(~/Library/HTTPStorages/ai.perplexity.macv3.binarycookies) and authenticates
+via the Perplexity NextAuth session — unlike ChatGPT there is NO bearer token,
+the ``__Secure-next-auth.session-token`` cookie on ``www.perplexity.ai`` carries
+auth on its own.
+
+Mirrors the shipped ChatGPT/Claude local-session adapters: same public shape
+(``build_perplexity_session``, ``discover_perplexity_local_session``, a bundle
+materializer). The binary-cookie parser is reused from
+``chatgpt_local_session`` (single source of truth — never duplicated here).
+
+His own account, his own data — a legitimate local puller, the same pattern as
+the ChatGPT and Claude adapters.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from .chatgpt_local_session import (
+    Cookie,
+    build_cookie_header,
+    parse_binary_cookies,
+)
+
+DEFAULT_PERPLEXITY_COOKIE_JAR = Path(
+    "/Users/4jp/Library/HTTPStorages/ai.perplexity.macv3.binarycookies"
+)
+PERPLEXITY_HOST = "www.perplexity.ai"
+PERPLEXITY_COOKIE_HOST = "www.perplexity.ai"
+PERPLEXITY_SESSION_COOKIE = "__Secure-next-auth.session-token"  # allow-secret
+PERPLEXITY_USER_AGENT = "Perplexity-Mac"
+
+
+class PerplexityLocalSessionError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class PerplexityHttpSession:
+    cookies: list[Cookie]
+    session_payload: dict[str, Any]
+    account_id: str
+    account_email: str
+    account_username: str
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# HTTP client
+# ---------------------------------------------------------------------------
+
+
+def resolve_perplexity_cookie_jar(
+    cookie_jar: Path = DEFAULT_PERPLEXITY_COOKIE_JAR,
+) -> Path:
+    path = cookie_jar.resolve()
+    if not path.exists():
+        raise PerplexityLocalSessionError(
+            f"Perplexity cookie jar does not exist: {path}\n"
+            "Sign in to the Perplexity macOS app so it writes its session cookies."
+        )
+    data = path.read_bytes()[:4]
+    if data != b"cook":
+        raise PerplexityLocalSessionError(
+            f"Perplexity cookie jar has unexpected format (expected 'cook' magic): {path}"
+        )
+    return path
+
+
+def _request_json(
+    cookies: list[Cookie],
+    url: str,
+    *,
+    timeout: int = 30,
+) -> Any:
+    headers: dict[str, str] = {
+        "Cookie": build_cookie_header(cookies, url),
+        "User-Agent": PERPLEXITY_USER_AGENT,
+        "Accept": "application/json,*/*",
+        "Referer": f"https://{PERPLEXITY_HOST}/",
+        "Origin": f"https://{PERPLEXITY_HOST}",
+    }
+    request = Request(url, headers=headers, method="GET")
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except HTTPError as error:
+        body = error.read().decode("utf-8", "replace")
+        raise PerplexityLocalSessionError(
+            f"{error.code} while fetching {url}: {body[:500]}"
+        ) from error
+    except URLError as error:
+        raise PerplexityLocalSessionError(
+            f"Network error while fetching {url}: {error}"
+        ) from error
+
+
+def _fetch_session(cookies: list[Cookie]) -> dict[str, Any]:
+    url = f"https://{PERPLEXITY_HOST}/api/auth/session"
+    payload = _request_json(cookies, url)
+    if not isinstance(payload, dict):
+        raise PerplexityLocalSessionError("Perplexity session payload was not a JSON object.")
+    return payload
+
+
+def _session_is_valid(payload: dict[str, Any]) -> bool:
+    user = payload.get("user") or {}
+    return bool(user.get("id"))
+
+
+def _build_session_from_cookies(cookies: list[Cookie]) -> PerplexityHttpSession | None:
+    try:
+        session_payload = _fetch_session(cookies)
+    except PerplexityLocalSessionError:
+        return None
+    if not _session_is_valid(session_payload):
+        return None
+    user = session_payload.get("user") or {}
+    return PerplexityHttpSession(
+        cookies=cookies,
+        session_payload=session_payload,
+        account_id=user.get("id") or "",
+        account_email=user.get("email") or "",
+        account_username=user.get("username") or "",
+    )
+
+
+def build_perplexity_session(
+    cookie_jar: Path = DEFAULT_PERPLEXITY_COOKIE_JAR,
+) -> PerplexityHttpSession:
+    try:
+        path = resolve_perplexity_cookie_jar(cookie_jar)
+        cookies = parse_binary_cookies(path)
+        session = _build_session_from_cookies(cookies)
+        if session is not None:
+            return session
+    except PerplexityLocalSessionError:
+        pass
+
+    raise PerplexityLocalSessionError(
+        "Unable to establish a Perplexity session from the native app cookie jar. "
+        "Sign in to the Perplexity macOS app and try again."
+    )
+
+
+def fetch_json(session: PerplexityHttpSession, url: str) -> Any:
+    return _request_json(session.cookies, url)
+
+
+# ---------------------------------------------------------------------------
+# Step-block extraction (INITIAL_QUERY -> user query, FINAL -> assistant answer)
+# ---------------------------------------------------------------------------
+
+
+def _parse_entry_steps(entry: dict[str, Any]) -> list[dict[str, Any]]:
+    """Parse one thread entry's ``text`` field into its list of step blocks.
+
+    Each ``entries[i].text`` is a JSON *string* that parses to a list of step
+    blocks with a ``step_type`` in {INITIAL_QUERY, SEARCH_WEB, SEARCH_RESULTS,
+    FINAL}. Returns ``[]`` on any malformed entry.
+    """
+    raw = entry.get("text")
+    if not isinstance(raw, str):
+        return []
+    try:
+        steps = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    if not isinstance(steps, list):
+        return []
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def extract_user_query(steps: list[dict[str, Any]]) -> str:
+    """User query = the INITIAL_QUERY step block -> ``content.query``."""
+    for step in steps:
+        if step.get("step_type") == "INITIAL_QUERY":
+            content = step.get("content") or {}
+            query = content.get("query")
+            if isinstance(query, str):
+                return query
+    return ""
+
+
+def extract_assistant_answer(steps: list[dict[str, Any]]) -> str:
+    """Assistant answer = the FINAL step block.
+
+    ``content.answer`` is itself a JSON string parsing to ``{"answer": "<md>"}``;
+    the inner ``.answer`` markdown is returned. Falls back to the raw string if
+    it does not parse as the nested envelope.
+    """
+    for step in steps:
+        if step.get("step_type") == "FINAL":
+            content = step.get("content") or {}
+            answer = content.get("answer")
+            if not isinstance(answer, str):
+                return ""
+            try:
+                inner = json.loads(answer)
+            except (json.JSONDecodeError, TypeError):
+                return answer
+            if isinstance(inner, dict) and isinstance(inner.get("answer"), str):
+                return inner["answer"]
+            return answer
+    return ""
+
+
+def _normalize_title(title: str) -> str:
+    return " ".join((title or "").split()).strip()
+
+
+def normalize_thread(thread_summary: dict[str, Any], detail: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a Perplexity thread (summary + detail) to a corpus record.
+
+    Shape:
+        {thread_uid, conversation_id, title_raw, title_normalized,
+         messages:[{role, text}], url, source}
+    """
+    uuid = thread_summary.get("uuid") or detail.get("uuid") or ""
+    title_raw = thread_summary.get("title") or detail.get("title") or ""
+    link = thread_summary.get("link") or ""
+    if link.startswith("/"):
+        url = f"https://{PERPLEXITY_HOST}{link}"
+    elif link:
+        url = link
+    else:
+        url = f"https://{PERPLEXITY_HOST}/search/{uuid}"
+
+    messages: list[dict[str, str]] = []
+    for entry in detail.get("entries") or []:
+        steps = _parse_entry_steps(entry)
+        if not steps:
+            continue
+        query = extract_user_query(steps)
+        if query:
+            messages.append({"role": "user", "text": query})
+        answer = extract_assistant_answer(steps)
+        if answer:
+            messages.append({"role": "assistant", "text": answer})
+
+    return {
+        "thread_uid": uuid,
+        "conversation_id": uuid,
+        "title_raw": title_raw,
+        "title_normalized": _normalize_title(title_raw),
+        "messages": messages,
+        "url": url,
+        "source": "perplexity-local-session",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+def _list_recent_threads(
+    session: PerplexityHttpSession,
+    *,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Page through ``list_recent`` until a short page is returned."""
+    all_threads: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        query = urlencode({"limit": limit, "offset": offset})
+        url = f"https://{PERPLEXITY_HOST}/rest/thread/list_recent?{query}"
+        page = fetch_json(session, url)
+        if not isinstance(page, list):
+            break
+        all_threads.extend(page)
+        if len(page) < limit:
+            break
+        offset += limit
+    return all_threads
+
+
+def _fetch_thread_detail(session: PerplexityHttpSession, uuid: str) -> dict[str, Any]:
+    url = f"https://{PERPLEXITY_HOST}/rest/thread/{uuid}"
+    detail = fetch_json(session, url)
+    if not isinstance(detail, dict):
+        raise PerplexityLocalSessionError(f"Thread detail for {uuid} was not a JSON object.")
+    return detail
+
+
+def discover_perplexity_local_session(
+    cookie_jar: Path = DEFAULT_PERPLEXITY_COOKIE_JAR,
+) -> dict[str, Any]:
+    session = build_perplexity_session(cookie_jar)
+    user = session.session_payload.get("user") or {}
+    threads = _list_recent_threads(session)
+
+    return {
+        "generated_at": now_iso(),
+        "cookie_jar": str(cookie_jar.resolve()),
+        "adapter_type": "perplexity-local-session",
+        "collection_scope": "local-session",
+        "session_state": "ready",
+        "account_id": session.account_id,
+        "account_email": session.account_email,
+        "account_username": session.account_username,
+        "subscription_tier": user.get("subscription_tier") or "",
+        "conversation_count": len(threads),
+        "recommended_command": (
+            "cce provider import --provider perplexity --mode local-session --register --build"
+        ),
+        "calibration_only": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Bundle fetching + materialization
+# ---------------------------------------------------------------------------
+
+
+def fetch_perplexity_local_session_bundle(
+    cookie_jar: Path = DEFAULT_PERPLEXITY_COOKIE_JAR,
+    *,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Fetch every thread + detail and normalize each to a corpus record."""
+    session = build_perplexity_session(cookie_jar)
+    summaries = _list_recent_threads(session, limit=limit)
+
+    normalized_threads: list[dict[str, Any]] = []
+    detail_failures: list[dict[str, Any]] = []
+    fetched_count = 0
+
+    for summary in summaries:
+        uuid = summary.get("uuid")
+        if not uuid:
+            continue
+        try:
+            detail = _fetch_thread_detail(session, uuid)
+            normalized_threads.append(normalize_thread(summary, detail))
+            fetched_count += 1
+        except Exception as exc:  # noqa: BLE001 - record and continue
+            detail_failures.append({"uuid": uuid, "error": str(exc)})
+
+    acquisition_report = {
+        "generated_at": now_iso(),
+        "total_listed": len(summaries),
+        "fetched_count": fetched_count,
+        "failure_count": len(detail_failures),
+    }
+
+    return {
+        "generated_at": now_iso(),
+        "cookie_jar": str(cookie_jar.resolve()),
+        "adapter_type": "perplexity-local-session",
+        "collection_scope": "local-session",
+        "account_id": session.account_id,
+        "account_email": session.account_email,
+        "account_username": session.account_username,
+        "thread_summaries": summaries,
+        "threads": normalized_threads,
+        "thread_detail_failures": detail_failures,
+        "total_count": len(summaries),
+        "fetched_count": fetched_count,
+        "acquisition_report": acquisition_report,
+    }
+
+
+def materialize_perplexity_local_session(
+    output_root: Path,
+    *,
+    cookie_jar: Path = DEFAULT_PERPLEXITY_COOKIE_JAR,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Fetch all threads and write normalized per-thread records under ``output_root``.
+
+    Writes ``threads/<uuid>.json`` per thread plus a ``threads-index.json``
+    manifest. Returns a summary dict (never the conversation bodies).
+    """
+    output_root = output_root.resolve()
+    bundle = fetch_perplexity_local_session_bundle(cookie_jar, limit=limit)
+
+    threads_dir = output_root / "threads"
+    threads_dir.mkdir(parents=True, exist_ok=True)
+
+    index_entries: list[dict[str, Any]] = []
+    written = 0
+    for thread in bundle["threads"]:
+        uuid = thread.get("thread_uid")
+        if not uuid:
+            continue
+        (threads_dir / f"{uuid}.json").write_text(
+            json.dumps(thread, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+        written += 1
+        index_entries.append(
+            {
+                "thread_uid": uuid,
+                "title_normalized": thread.get("title_normalized", ""),
+                "message_count": len(thread.get("messages") or []),
+                "url": thread.get("url", ""),
+            }
+        )
+
+    index = {
+        "generated_at": now_iso(),
+        "source": "perplexity-local-session",
+        "account_email": bundle["account_email"],
+        "account_username": bundle["account_username"],
+        "thread_count": written,
+        "fetched_count": bundle["fetched_count"],
+        "detail_failures": bundle["thread_detail_failures"],
+        "threads": index_entries,
+    }
+    (output_root / "threads-index.json").write_text(
+        json.dumps(index, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+    return {
+        "generated_at": now_iso(),
+        "output_root": str(output_root),
+        "threads_written": written,
+        "fetched_count": bundle["fetched_count"],
+        "failure_count": len(bundle["thread_detail_failures"]),
+    }
+
+
+def render_discovery_text(payload: dict[str, Any]) -> str:
+    lines = [
+        f"Perplexity cookie jar: {payload.get('cookie_jar', 'unknown')}",
+        f"Generated: {payload['generated_at']}",
+        f"Session state: {payload['session_state']}",
+        f"Account: {payload.get('account_email') or payload.get('account_id') or 'unknown'}",
+        f"Threads: {payload['conversation_count']}",
+        f"Calibration only: {payload['calibration_only']}",
+        f"Recommended command: {payload['recommended_command']}",
+    ]
+    return "\n".join(lines)

--- a/src/conversation_corpus_engine/perplexity_local_session.py
+++ b/src/conversation_corpus_engine/perplexity_local_session.py
@@ -104,9 +104,7 @@ def _request_json(
             f"{error.code} while fetching {url}: {body[:500]}"
         ) from error
     except URLError as error:
-        raise PerplexityLocalSessionError(
-            f"Network error while fetching {url}: {error}"
-        ) from error
+        raise PerplexityLocalSessionError(f"Network error while fetching {url}: {error}") from error
 
 
 def _fetch_session(cookies: list[Cookie]) -> dict[str, Any]:

--- a/src/conversation_corpus_engine/provider_catalog.py
+++ b/src/conversation_corpus_engine/provider_catalog.py
@@ -71,8 +71,11 @@ PROVIDER_CONFIG: dict[str, dict[str, Any]] = {
         "inbox_rel": "perplexity/inbox",
         "default_corpus_id": "perplexity-history-memory",
         "default_corpus_name": "Perplexity History Memory",
-        "local_source_root": "/Users/4jp/Library/Containers/ai.perplexity.mac",
-        "local_session_supported": False,
+        "local_source_root": "/Users/4jp/Library/HTTPStorages",
+        "local_session_supported": True,
+        "local_session_cookie_jar": (
+            "/Users/4jp/Library/HTTPStorages/ai.perplexity.macv3.binarycookies"
+        ),
         "calibration_only": True,
     },
     "copilot": {

--- a/src/conversation_corpus_engine/provider_import.py
+++ b/src/conversation_corpus_engine/provider_import.py
@@ -17,6 +17,8 @@ from .import_chatgpt_local_session_corpus import import_chatgpt_local_session_co
 from .import_claude_export_corpus import import_claude_export_corpus
 from .import_claude_local_session_corpus import import_claude_local_session_corpus
 from .import_document_export_corpus import import_document_export_corpus
+from .import_perplexity_local_session_corpus import import_perplexity_local_session_corpus
+from .perplexity_local_session import DEFAULT_PERPLEXITY_COOKIE_JAR
 from .provider_catalog import (
     default_source_drop_root,
     get_provider_config,
@@ -45,6 +47,20 @@ def bootstrap_manual_review(
     )
 
 
+def _resolve_perplexity_cookie_jar(local_root: Path | None) -> Path:
+    """Resolve the Perplexity cookie jar from ``local_root``.
+
+    ``local_root`` may be the cookie-jar file itself, the ``HTTPStorages``
+    directory that contains it, or unset (fall back to the catalog default).
+    """
+    if local_root is None:
+        return DEFAULT_PERPLEXITY_COOKIE_JAR.resolve()
+    resolved = local_root.resolve()
+    if resolved.is_dir():
+        return (resolved / DEFAULT_PERPLEXITY_COOKIE_JAR.name).resolve()
+    return resolved
+
+
 def resolve_provider_import_source(
     *,
     provider: str,
@@ -63,6 +79,10 @@ def resolve_provider_import_source(
 
     if provider == "chatgpt" and mode == "local-session":
         resolved_cookie_jar = (local_root or DEFAULT_CHATGPT_COOKIE_JAR).resolve()
+        return resolved_cookie_jar, {"resolution": "local-session-cookie-jar"}
+
+    if provider == "perplexity" and mode == "local-session":
+        resolved_cookie_jar = _resolve_perplexity_cookie_jar(local_root)
         return resolved_cookie_jar, {"resolution": "local-session-cookie-jar"}
 
     resolved_source_drop_root = (
@@ -156,6 +176,16 @@ def import_provider_corpus(
             name=resolved_name,
             throttle=throttle,
             authorization=authorization,
+        )
+    elif provider == "perplexity" and mode == "local-session":
+        resolved_corpus_id = resolved_corpus_id or config["default_corpus_id"]
+        resolved_name = resolved_name or config["default_corpus_name"]
+        import_result = import_perplexity_local_session_corpus(
+            resolved_source_path,
+            resolved_output_root,
+            corpus_id=resolved_corpus_id,
+            name=resolved_name,
+            throttle=throttle,
         )
     elif provider == "chatgpt":
         import_result = import_chatgpt_export_corpus(

--- a/tests/test_perplexity_local_session.py
+++ b/tests/test_perplexity_local_session.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from conversation_corpus_engine import perplexity_local_session as module  # noqa: E402
+from conversation_corpus_engine.perplexity_local_session import (  # noqa: E402
+    PerplexityHttpSession,
+    PerplexityLocalSessionError,
+)
+
+# Import the shared binary-cookie-jar builder from the ChatGPT adapter's tests.
+from tests.test_chatgpt_local_session import build_binary_cookie_jar  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixture: the real step-block shape (INITIAL_QUERY, SEARCH_WEB, FINAL).
+# The `entries[i].text` field is a JSON *string* of a list of step blocks;
+# the FINAL block's `content.answer` is itself a JSON string {"answer": "..."}.
+# ---------------------------------------------------------------------------
+
+
+def _entry_text() -> str:
+    steps = [
+        {"step_type": "INITIAL_QUERY", "content": {"query": "What is the capital of France?"}},
+        {"step_type": "SEARCH_WEB", "content": {"queries": ["capital of France"]}},
+        {"step_type": "SEARCH_RESULTS", "content": {"web_results": [{"url": "https://x"}]}},
+        {
+            "step_type": "FINAL",
+            "content": {
+                "answer": json.dumps(
+                    {"answer": "The capital of France is **Paris**."}
+                )
+            },
+        },
+    ]
+    return json.dumps(steps)
+
+
+def _sample_detail() -> dict[str, object]:
+    return {"entries": [{"text": _entry_text()}], "background_entries": []}
+
+
+def _sample_summary() -> dict[str, object]:
+    return {
+        "uuid": "thread-abc",
+        "title": "  France   capital  ",
+        "link": "/search/thread-abc",
+        "status": "COMPLETED",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Step-block extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_user_query_from_initial_query_block() -> None:
+    steps = module._parse_entry_steps({"text": _entry_text()})
+    assert module.extract_user_query(steps) == "What is the capital of France?"
+
+
+def test_extract_assistant_answer_unwraps_nested_json() -> None:
+    steps = module._parse_entry_steps({"text": _entry_text()})
+    assert module.extract_assistant_answer(steps) == "The capital of France is **Paris**."
+
+
+def test_extract_user_query_missing_returns_empty() -> None:
+    steps = [{"step_type": "FINAL", "content": {"answer": "{}"}}]
+    assert module.extract_user_query(steps) == ""
+
+
+def test_extract_assistant_answer_missing_final_returns_empty() -> None:
+    steps = [{"step_type": "INITIAL_QUERY", "content": {"query": "hi"}}]
+    assert module.extract_assistant_answer(steps) == ""
+
+
+def test_extract_assistant_answer_falls_back_on_unwrappable_string() -> None:
+    steps = [{"step_type": "FINAL", "content": {"answer": "plain not-json text"}}]
+    assert module.extract_assistant_answer(steps) == "plain not-json text"
+
+
+def test_parse_entry_steps_tolerates_malformed_text() -> None:
+    assert module._parse_entry_steps({"text": "not json"}) == []
+    assert module._parse_entry_steps({"text": None}) == []
+    assert module._parse_entry_steps({}) == []
+
+
+# ---------------------------------------------------------------------------
+# Thread normalization
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_thread_produces_corpus_record() -> None:
+    record = module.normalize_thread(_sample_summary(), _sample_detail())
+    assert record["thread_uid"] == "thread-abc"
+    assert record["conversation_id"] == "thread-abc"
+    assert record["title_raw"] == "  France   capital  "
+    assert record["title_normalized"] == "France capital"
+    assert record["source"] == "perplexity-local-session"
+    assert record["url"] == "https://www.perplexity.ai/search/thread-abc"
+    assert record["messages"] == [
+        {"role": "user", "text": "What is the capital of France?"},
+        {"role": "assistant", "text": "The capital of France is **Paris**."},
+    ]
+
+
+def test_normalize_thread_skips_empty_entries() -> None:
+    detail = {"entries": [{"text": "not json"}, {"text": _entry_text()}]}
+    record = module.normalize_thread(_sample_summary(), detail)
+    assert len(record["messages"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Session validity / discovery (network monkeypatched — no real calls)
+# ---------------------------------------------------------------------------
+
+
+def test_session_is_valid_requires_user_id() -> None:
+    assert module._session_is_valid({"user": {"id": "u1"}})
+    assert not module._session_is_valid({"user": {}})
+    assert not module._session_is_valid({})
+
+
+def test_build_perplexity_session_raises_when_invalid(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    jar = tmp_path / "perplexity.binarycookies"
+    jar.write_bytes(
+        build_binary_cookie_jar(
+            [{"domain": "www.perplexity.ai", "name": "x", "value": "y"}]
+        )
+    )
+    monkeypatch.setattr(module, "_fetch_session", lambda cookies: {"user": {}})
+    with pytest.raises(PerplexityLocalSessionError, match="Perplexity macOS app"):
+        module.build_perplexity_session(jar)
+
+
+def test_resolve_cookie_jar_missing_raises_signin_message(tmp_path: Path) -> None:
+    with pytest.raises(PerplexityLocalSessionError, match="Sign in to the Perplexity macOS app"):
+        module.resolve_perplexity_cookie_jar(tmp_path / "nope.binarycookies")
+
+
+def _fake_session() -> PerplexityHttpSession:
+    return PerplexityHttpSession(
+        cookies=[],
+        session_payload={
+            "user": {
+                "id": "u1",
+                "email": "u@example.com",
+                "username": "u",
+                "subscription_tier": "pro",
+            }
+        },
+        account_id="u1",
+        account_email="u@example.com",
+        account_username="u",
+    )
+
+
+def test_discover_perplexity_local_session_returns_summary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    jar = tmp_path / "perplexity.binarycookies"
+    jar.write_bytes(
+        build_binary_cookie_jar(
+            [{"domain": "www.perplexity.ai", "name": "x", "value": "y"}]
+        )
+    )
+    monkeypatch.setattr(module, "build_perplexity_session", lambda cookie_jar: _fake_session())
+    monkeypatch.setattr(
+        module, "_list_recent_threads", lambda session, **_kw: [_sample_summary()]
+    )
+
+    payload = module.discover_perplexity_local_session(jar)
+    assert payload["session_state"] == "ready"
+    assert payload["conversation_count"] == 1
+    assert payload["account_email"] == "u@example.com"
+    assert payload["adapter_type"] == "perplexity-local-session"
+
+
+def test_materialize_writes_threads_and_index(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    jar = tmp_path / "perplexity.binarycookies"
+    jar.write_bytes(
+        build_binary_cookie_jar(
+            [{"domain": "www.perplexity.ai", "name": "x", "value": "y"}]
+        )
+    )
+    monkeypatch.setattr(module, "build_perplexity_session", lambda cookie_jar: _fake_session())
+    monkeypatch.setattr(
+        module, "_list_recent_threads", lambda session, **_kw: [_sample_summary()]
+    )
+    monkeypatch.setattr(
+        module, "_fetch_thread_detail", lambda session, uuid: _sample_detail()
+    )
+
+    out = tmp_path / "out"
+    summary = module.materialize_perplexity_local_session(out, cookie_jar=jar)
+
+    assert summary["threads_written"] == 1
+    assert summary["fetched_count"] == 1
+    thread_file = out / "threads" / "thread-abc.json"
+    assert thread_file.exists()
+    written = json.loads(thread_file.read_text(encoding="utf-8"))
+    assert written["messages"][0]["role"] == "user"
+
+    index = json.loads((out / "threads-index.json").read_text(encoding="utf-8"))
+    assert index["thread_count"] == 1
+    assert index["threads"][0]["message_count"] == 2
+
+
+def test_render_discovery_text_includes_key_fields() -> None:
+    text = module.render_discovery_text(
+        {
+            "cookie_jar": "/tmp/cookies",
+            "generated_at": "2026-07-23T00:00:00+00:00",
+            "session_state": "ready",
+            "account_email": "u@example.com",
+            "account_id": "u1",
+            "conversation_count": 20,
+            "calibration_only": True,
+            "recommended_command": "cce provider import --provider perplexity",
+        }
+    )
+    assert "Perplexity cookie jar: /tmp/cookies" in text
+    assert "u@example.com" in text
+    assert "Threads: 20" in text

--- a/tests/test_perplexity_local_session.py
+++ b/tests/test_perplexity_local_session.py
@@ -31,11 +31,7 @@ def _entry_text() -> str:
         {"step_type": "SEARCH_RESULTS", "content": {"web_results": [{"url": "https://x"}]}},
         {
             "step_type": "FINAL",
-            "content": {
-                "answer": json.dumps(
-                    {"answer": "The capital of France is **Paris**."}
-                )
-            },
+            "content": {"answer": json.dumps({"answer": "The capital of France is **Paris**."})},
         },
     ]
     return json.dumps(steps)
@@ -131,9 +127,7 @@ def test_build_perplexity_session_raises_when_invalid(
 ) -> None:
     jar = tmp_path / "perplexity.binarycookies"
     jar.write_bytes(
-        build_binary_cookie_jar(
-            [{"domain": "www.perplexity.ai", "name": "x", "value": "y"}]
-        )
+        build_binary_cookie_jar([{"domain": "www.perplexity.ai", "name": "x", "value": "y"}])
     )
     monkeypatch.setattr(module, "_fetch_session", lambda cookies: {"user": {}})
     with pytest.raises(PerplexityLocalSessionError, match="Perplexity macOS app"):
@@ -167,14 +161,10 @@ def test_discover_perplexity_local_session_returns_summary(
 ) -> None:
     jar = tmp_path / "perplexity.binarycookies"
     jar.write_bytes(
-        build_binary_cookie_jar(
-            [{"domain": "www.perplexity.ai", "name": "x", "value": "y"}]
-        )
+        build_binary_cookie_jar([{"domain": "www.perplexity.ai", "name": "x", "value": "y"}])
     )
     monkeypatch.setattr(module, "build_perplexity_session", lambda cookie_jar: _fake_session())
-    monkeypatch.setattr(
-        module, "_list_recent_threads", lambda session, **_kw: [_sample_summary()]
-    )
+    monkeypatch.setattr(module, "_list_recent_threads", lambda session, **_kw: [_sample_summary()])
 
     payload = module.discover_perplexity_local_session(jar)
     assert payload["session_state"] == "ready"
@@ -188,17 +178,11 @@ def test_materialize_writes_threads_and_index(
 ) -> None:
     jar = tmp_path / "perplexity.binarycookies"
     jar.write_bytes(
-        build_binary_cookie_jar(
-            [{"domain": "www.perplexity.ai", "name": "x", "value": "y"}]
-        )
+        build_binary_cookie_jar([{"domain": "www.perplexity.ai", "name": "x", "value": "y"}])
     )
     monkeypatch.setattr(module, "build_perplexity_session", lambda cookie_jar: _fake_session())
-    monkeypatch.setattr(
-        module, "_list_recent_threads", lambda session, **_kw: [_sample_summary()]
-    )
-    monkeypatch.setattr(
-        module, "_fetch_thread_detail", lambda session, uuid: _sample_detail()
-    )
+    monkeypatch.setattr(module, "_list_recent_threads", lambda session, **_kw: [_sample_summary()])
+    monkeypatch.setattr(module, "_fetch_thread_detail", lambda session, uuid: _sample_detail())
 
     out = tmp_path / "out"
     summary = module.materialize_perplexity_local_session(out, cookie_jar=jar)

--- a/tests/test_provider_import.py
+++ b/tests/test_provider_import.py
@@ -11,6 +11,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from conversation_corpus_engine.corpus_store import CorpusStoreError, register_corpus_store
 from conversation_corpus_engine.federation import list_registered_corpora
 from conversation_corpus_engine.perplexity_local_session import DEFAULT_PERPLEXITY_COOKIE_JAR
+from conversation_corpus_engine.provider_catalog import get_provider_config
 from conversation_corpus_engine.provider_import import (
     default_output_root,
     import_provider_corpus,
@@ -143,8 +144,6 @@ class PerplexityLocalSessionResolutionTests(unittest.TestCase):
         # already-resolved (store_root, corpus_id); corpus_id resolution moved up
         # into import_provider_corpus, which uses the catalog default_corpus_id for
         # perplexity local-session. Assert the invariant at both its new homes.
-        from conversation_corpus_engine.provider_catalog import get_provider_config
-
         corpus_id = get_provider_config("perplexity")["default_corpus_id"]
         self.assertEqual(corpus_id, "perplexity-history-memory")
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_provider_import.py
+++ b/tests/test_provider_import.py
@@ -10,7 +10,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from conversation_corpus_engine.corpus_store import CorpusStoreError, register_corpus_store
 from conversation_corpus_engine.federation import list_registered_corpora
-from conversation_corpus_engine.provider_import import import_provider_corpus
+from conversation_corpus_engine.perplexity_local_session import DEFAULT_PERPLEXITY_COOKIE_JAR
+from conversation_corpus_engine.provider_import import (
+    default_output_root,
+    import_provider_corpus,
+    resolve_provider_import_source,
+)
 from conversation_corpus_engine.provider_readiness import build_provider_readiness
 
 
@@ -93,6 +98,58 @@ class ProviderImportTests(unittest.TestCase):
             self.assertFalse(outside_destination.exists())
             self.assertEqual(registry_path.read_bytes(), registry_before)
             self.assertFalse((project_root / "reports").exists())
+
+
+class PerplexityLocalSessionResolutionTests(unittest.TestCase):
+    """Resolver + output-root wiring for perplexity local-session (no network)."""
+
+    def test_resolver_defaults_to_catalog_cookie_jar(self) -> None:
+        resolved, meta = resolve_provider_import_source(
+            provider="perplexity",
+            mode="local-session",
+            project_root=Path("/tmp/project"),
+        )
+        self.assertEqual(meta["resolution"], "local-session-cookie-jar")
+        self.assertEqual(resolved, DEFAULT_PERPLEXITY_COOKIE_JAR.resolve())
+
+    def test_resolver_maps_httpstorages_dir_to_cookie_jar(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            http_storages = Path(tmpdir) / "HTTPStorages"
+            http_storages.mkdir()
+            resolved, meta = resolve_provider_import_source(
+                provider="perplexity",
+                mode="local-session",
+                project_root=Path("/tmp/project"),
+                local_root=http_storages,
+            )
+            self.assertEqual(meta["resolution"], "local-session-cookie-jar")
+            self.assertEqual(resolved.name, DEFAULT_PERPLEXITY_COOKIE_JAR.name)
+            self.assertEqual(resolved.parent, http_storages.resolve())
+
+    def test_resolver_accepts_explicit_cookie_jar_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jar = Path(tmpdir) / "ai.perplexity.macv3.binarycookies"
+            jar.write_bytes(b"cook")
+            resolved, _meta = resolve_provider_import_source(
+                provider="perplexity",
+                mode="local-session",
+                project_root=Path("/tmp/project"),
+                local_root=jar,
+            )
+            self.assertEqual(resolved, jar.resolve())
+
+    def test_default_output_root_uses_default_corpus_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_drop_root = Path(tmpdir) / "drop"
+            source_drop_root.mkdir()
+            root = default_output_root(
+                provider="perplexity",
+                mode="local-session",
+                project_root=Path(tmpdir) / "project",
+                source_drop_root=source_drop_root,
+            )
+            # local-session uses default_corpus_id, not a fallback.
+            self.assertTrue(str(root).endswith("perplexity-history-memory"))
 
 
 if __name__ == "__main__":

--- a/tests/test_provider_import.py
+++ b/tests/test_provider_import.py
@@ -139,16 +139,17 @@ class PerplexityLocalSessionResolutionTests(unittest.TestCase):
             self.assertEqual(resolved, jar.resolve())
 
     def test_default_output_root_uses_default_corpus_id(self) -> None:
+        # Post corpus-store-custody refactor (#64), default_output_root takes an
+        # already-resolved (store_root, corpus_id); corpus_id resolution moved up
+        # into import_provider_corpus, which uses the catalog default_corpus_id for
+        # perplexity local-session. Assert the invariant at both its new homes.
+        from conversation_corpus_engine.provider_catalog import get_provider_config
+
+        corpus_id = get_provider_config("perplexity")["default_corpus_id"]
+        self.assertEqual(corpus_id, "perplexity-history-memory")
         with tempfile.TemporaryDirectory() as tmpdir:
-            source_drop_root = Path(tmpdir) / "drop"
-            source_drop_root.mkdir()
-            root = default_output_root(
-                provider="perplexity",
-                mode="local-session",
-                project_root=Path(tmpdir) / "project",
-                source_drop_root=source_drop_root,
-            )
-            # local-session uses default_corpus_id, not a fallback.
+            store_root = Path(tmpdir) / "store"
+            root = default_output_root(corpus_store_root=store_root, corpus_id=corpus_id)
             self.assertTrue(str(root).endswith("perplexity-history-memory"))
 
 


### PR DESCRIPTION
## What

Two connected additions, both keeping the engine's contract intact:

1. **CCE→aps brainstorm bridge** (`aps_bridge.py`) — the connector the pipeline was missing. Queries the federated conversation corpora for a subject's brainstorm threads and materializes matches as a markdown notes dir that `aps corpus ingest` reads as provenance. Re-runnable, so a living brainstorm keeps feeding an aps learning subject. The caller passes `--out` (canonically an ARCA-sealed private store — never a public tree, never gitignored).

2. **Perplexity local-session capture** — mirrors the shipped ChatGPT/Claude local-session adapters:
   - `perplexity_local_session.py` — NextAuth session-cookie auth (no bearer), `list_recent` + `/rest/thread/{uuid}` with `INITIAL_QUERY→query` / `FINAL→answer` step-block extraction.
   - `import_perplexity_local_session_corpus.py` — renders threads to conversation markdown, delegates to the document-export adapter so it federates.
   - `provider_import.py` — resolver + dispatch + output-root wired for `perplexity`/`local-session`.
   - `provider_catalog.py` — perplexity now `local_session_supported: true`, correct macv3 cookie-jar path.

## Verification

- `pytest -q` → **369 passed** (18 new fixture tests, no network).
- `ruff check src` → clean.
- Bridge pulled 23 real script-writing threads from ChatGPT + Claude + Perplexity into a screenwriting aps subject; `aps plan generate` emits a 28-module path, ledger INTACT.
- Perplexity: 20 threads imported, federated, and searchable (`search_documents_v4` — "RuPaul drag race" → 5 hits, score 16.2); federation registry now lists all three providers.

No conversation data is committed — corpora live in a private ARCA-sealed store outside the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)